### PR TITLE
docs: Remove extra ellipses from package.json examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,9 @@ Add a `start` script to `package.json`, with configuration passed via
 command-line arguments:
 
 ```js
-...
   "scripts": {
     "start": "functions-framework --function-target=helloWorld"
   }
-...
 ```
 
 Use `npm start` to start the built-in local development server:
@@ -129,11 +127,9 @@ You can set command-line flags in your `package.json` via the `start` script.
 For example:
 
 ```js
-...
   "scripts": {
     "start": "functions-framework --function-target=helloWorld"
   }
-...
 ```
 
 # Enable CloudEvents handling for use with the event function signature


### PR DESCRIPTION
Simplifies the `package.json` reference in the docs.

- The reader already understands that `package.json` has other fields.
- It's not necessarily true that there are more fields below the property `scripts`.