### PR TITLE
Update function-to-app converter to depend on the module published to npm

### DIFF
--- a/converter/Dockerfile
+++ b/converter/Dockerfile
@@ -1,32 +1,10 @@
-FROM gcr.io/gae-runtimes/nodejs10_app_builder:nodejs10_20190306_10_15_3_RC00 AS functions-framework
-
-COPY *.js *.json LICENSE /functions-framework/
-COPY src /functions-framework/src
-COPY test /functions-framework/test
-WORKDIR /functions-framework
-RUN npm install --only=dev && npm run compile
-
 FROM gcr.io/gcp-runtimes/ubuntu_18_0_4
 
-# TODO: Once functions-framework npm module is published, do not include
-# functions-framework files in the image, just reference the published module in
-# package.json.
-COPY --from=functions-framework \
-    /functions-framework/package.json \
-    /functions-framework/LICENSE \
-    /functions-framework/
-COPY --from=functions-framework \
-    /functions-framework/build/src/*.js \
-    /functions-framework/build/src/*.d.ts \
-    /functions-framework/build/src/
+COPY convert .npmrc /converter/
 
-# TODO: Once functions-framework files from the parent directory are not needed,
-# run docker build and copy files from the current directory.
-COPY converter/convert converter/.npmrc /converter/
-
-COPY converter/without-package /converter/without-package
-COPY converter/with-package-without-framework /converter/with-package-without-framework
-COPY converter/with-package-with-framework /converter/with-package-with-framework
+COPY without-package /converter/without-package
+COPY with-package-without-framework /converter/with-package-without-framework
+COPY with-package-with-framework /converter/with-package-with-framework
 
 RUN apt-get update >/dev/null && \
     apt-get install -y jq >/dev/null

--- a/converter/convert
+++ b/converter/convert
@@ -12,8 +12,6 @@ mv * ${temp_dir}
 mkdir functions
 mv ${temp_dir}/* functions
 
-mv /functions-framework .
-
 if [[ ! -f functions/package.json ]]; then
   echo 'Handling functions without package.json'
   cp /converter/without-package/package.json .

--- a/converter/generate-package-lock
+++ b/converter/generate-package-lock
@@ -7,10 +7,7 @@
 set -e
 
 for dir in without-package with-package-without-framework with-package-with-framework; do
-  mkdir ${dir}/functions-framework
-  cp ../package.json ${dir}/functions-framework/
   rm ${dir}/package-lock.json
   npm --prefix ${dir} --package-lock-only install
-  rm -rf ${dir}/functions-framework
   rm -rf ${dir}/functions
 done

--- a/converter/with-package-without-framework/package-lock.json
+++ b/converter/with-package-without-framework/package-lock.json
@@ -3,7 +3,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@google-cloud/functions-framework": {
-      "version": "file:functions-framework",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/functions-framework/-/functions-framework-1.0.0.tgz",
+      "integrity": "sha512-Qm/vyMaSEA3A1w/2p1eKDskU//F6eFMGQW28NGXXlNtVSSX2qnShbTiFOOU6y4wO/GTto9YUH4sKFbysXP1zyA==",
       "requires": {
         "body-parser": "^1.18.3",
         "express": "^4.16.4",

--- a/converter/with-package-without-framework/package.json
+++ b/converter/with-package-without-framework/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@google-cloud/functions-framework": "file:functions-framework"
+    "@google-cloud/functions-framework": "^1.0.0"
   },
   "scripts": {
     "preinstall": "npm --prefix functions install",

--- a/converter/without-package/package-lock.json
+++ b/converter/without-package/package-lock.json
@@ -3,7 +3,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@google-cloud/functions-framework": {
-      "version": "file:functions-framework",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/functions-framework/-/functions-framework-1.0.0.tgz",
+      "integrity": "sha512-Qm/vyMaSEA3A1w/2p1eKDskU//F6eFMGQW28NGXXlNtVSSX2qnShbTiFOOU6y4wO/GTto9YUH4sKFbysXP1zyA==",
       "requires": {
         "body-parser": "^1.18.3",
         "express": "^4.16.4",

--- a/converter/without-package/package.json
+++ b/converter/without-package/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@google-cloud/functions-framework": "file:functions-framework"
+    "@google-cloud/functions-framework": "^1.0.0"
   },
   "scripts": {
     "start": "cd functions && functions-framework"


### PR DESCRIPTION
This replaces the local dependency on @google-cloud/functions-framework with the dependency on the module published to npm.