### PR TITLE
fix #4: Removes 'function' prefix from CLI args

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ exports.helloWorld = (req, res) => {
 Run the following command:
 
 ```sh
-npx @google-cloud/functions-framework --function-target=helloWorld
+npx @google-cloud/functions-framework --target=helloWorld
 ```
 
 Open http://localhost:8080/ in your browser and see *Hello, World*.
@@ -91,7 +91,7 @@ command-line arguments:
 
 ```js
   "scripts": {
-    "start": "functions-framework --function-target=helloWorld"
+    "start": "functions-framework --target=helloWorld"
   }
 ```
 
@@ -145,15 +145,15 @@ ignored.
 Command-line flag         | Environment variable      | Description
 ------------------------- | ------------------------- | -----------
 `--port`                    | `PORT`                    | The port on which the Functions Framework listens for requests. Default: `8080`
-`--function-target`         | `FUNCTION_TARGET`         | The name of the exported function to be invoked in response to requests. Default: `function`
-`--function-signature-type` | `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function. Default: `http`; accepted values: `http` or `event`
+`--target`         | `FUNCTION_TARGET`         | The name of the exported function to be invoked in response to requests. Default: `function`
+`--signature-type` | `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function. Default: `http`; accepted values: `http` or `event`
 
 You can set command-line flags in your `package.json` via the `start` script.
 For example:
 
 ```js
   "scripts": {
-    "start": "functions-framework --function-target=helloWorld"
+    "start": "functions-framework --target=helloWorld"
   }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import * as minimist from 'minimist';
 
 import {
   ErrorHandler,
-  FunctionSignatureType,
+  SignatureType,
   getServer,
   getUserFunction,
 } from './invoker';
@@ -46,8 +46,8 @@ const FLAG = {
 // Supported environment variables
 const ENV = {
   PORT: 'PORT',
-  TARGET: 'TARGET',
-  SIGNATURE_TYPE: 'SIGNATURE_TYPE', // underscore
+  TARGET: 'FUNCTION_TARGET',
+  SIGNATURE_TYPE: 'FUNCTION_SIGNATURE_TYPE', // underscore
 };
 
 enum NodeEnv {
@@ -62,13 +62,13 @@ const CODE_LOCATION = process.cwd();
 const PORT = argv[FLAG.PORT] || process.env[ENV.PORT] || '8080';
 const TARGET = argv[FLAG.TARGET] || process.env[ENV.TARGET] || 'function';
 
-const FUNCTION_SIGNATURE_TYPE_STRING =
+const SIGNATURE_TYPE_STRING =
   argv[FLAG.SIGNATURE_TYPE] || process.env[ENV.SIGNATURE_TYPE] || 'http';
-const FUNCTION_SIGNATURE_TYPE =
-  FunctionSignatureType[
-    FUNCTION_SIGNATURE_TYPE_STRING.toUpperCase() as keyof typeof FunctionSignatureType
+const SIGNATURE_TYPE =
+  SignatureType[
+    SIGNATURE_TYPE_STRING.toUpperCase() as keyof typeof SignatureType
   ];
-if (FUNCTION_SIGNATURE_TYPE === undefined) {
+if (SIGNATURE_TYPE === undefined) {
   console.error(`Function signature type must be one of 'http' or 'event'.`);
   process.exit(1);
 }
@@ -79,7 +79,7 @@ if (!USER_FUNCTION) {
   process.exit(1);
 }
 
-const SERVER = getServer(USER_FUNCTION!, FUNCTION_SIGNATURE_TYPE!);
+const SERVER = getServer(USER_FUNCTION!, SIGNATURE_TYPE!);
 const ERROR_HANDLER = new ErrorHandler(SERVER);
 SERVER.listen(PORT, () => {
   ERROR_HANDLER.register();

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ const FLAG = {
 };
 
 // Supported environment variables
-const ENV_VARIABLE = {
+const ENV = {
   PORT: 'PORT',
   TARGET: 'TARGET',
   SIGNATURE_TYPE: 'SIGNATURE_TYPE', // underscore
@@ -55,27 +55,25 @@ enum NodeEnv {
 }
 
 const argv = minimist(process.argv, {
-  string: [ENV_VARIABLE.PORT, FLAG.TARGET, FLAG.SIGNATURE_TYPE],
+  string: [FLAG.PORT, FLAG.TARGET, FLAG.SIGNATURE_TYPE],
 });
 
 const CODE_LOCATION = process.cwd();
-const PORT =
-  argv[ENV_VARIABLE.PORT] || process.env[ENV_VARIABLE.PORT] || '8080';
-const FUNCTION_TARGET =
-  argv[FLAG.TARGET] || process.env[ENV_VARIABLE.TARGET] || 'function';
+const PORT = argv[FLAG.PORT] || process.env[ENV.PORT] || '8080';
+const TARGET = argv[FLAG.TARGET] || process.env[ENV.TARGET] || 'function';
 
 const FUNCTION_SIGNATURE_TYPE_STRING =
-  argv[FLAG.SIGNATURE_TYPE] || process.env.FUNCTION_SIGNATURE_TYPE || 'http';
+  argv[FLAG.SIGNATURE_TYPE] || process.env[ENV.SIGNATURE_TYPE] || 'http';
 const FUNCTION_SIGNATURE_TYPE =
   FunctionSignatureType[
     FUNCTION_SIGNATURE_TYPE_STRING.toUpperCase() as keyof typeof FunctionSignatureType
   ];
 if (FUNCTION_SIGNATURE_TYPE === undefined) {
-  console.error(`FUNCTION_SIGNATURE_TYPE must be one of 'http' or 'event'.`);
+  console.error(`Function must be one of 'http' or 'event'.`);
   process.exit(1);
 }
 
-const USER_FUNCTION = getUserFunction(CODE_LOCATION, FUNCTION_TARGET);
+const USER_FUNCTION = getUserFunction(CODE_LOCATION, TARGET);
 if (!USER_FUNCTION) {
   console.error('Could not load the function, shutting down.');
   process.exit(1);
@@ -87,7 +85,7 @@ SERVER.listen(PORT, () => {
   ERROR_HANDLER.register();
   if (process.env.NODE_ENV !== NodeEnv.PRODUCTION) {
     console.log('Serving function...');
-    console.log(`Function: ${FUNCTION_TARGET}`);
+    console.log(`Function: ${TARGET}`);
     console.log(`URL: http://localhost:${PORT}/`);
   }
 }).setTimeout(0); // Disable automatic timeout on incoming connections.

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ const FUNCTION_SIGNATURE_TYPE =
     FUNCTION_SIGNATURE_TYPE_STRING.toUpperCase() as keyof typeof FunctionSignatureType
   ];
 if (FUNCTION_SIGNATURE_TYPE === undefined) {
-  console.error(`Function must be one of 'http' or 'event'.`);
+  console.error(`Function signature type must be one of 'http' or 'event'.`);
   process.exit(1);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@
 //     unmarshalled from an incoming request.
 
 import * as minimist from 'minimist';
+
 import {
   ErrorHandler,
   FunctionSignatureType,
@@ -35,23 +36,36 @@ import {
   getUserFunction,
 } from './invoker';
 
+// Supported command-line flags
+const FLAG = {
+  PORT: 'port',
+  TARGET: 'target',
+  SIGNATURE_TYPE: 'signature-type', // dash
+};
+
+// Supported environment variables
+const ENV_VARIABLE = {
+  PORT: 'PORT',
+  TARGET: 'TARGET',
+  SIGNATURE_TYPE: 'SIGNATURE_TYPE', // underscore
+};
+
 enum NodeEnv {
   PRODUCTION = 'production',
 }
 
 const argv = minimist(process.argv, {
-  string: ['port', 'function-target', 'function-signature-type'],
+  string: [ENV_VARIABLE.PORT, FLAG.TARGET, FLAG.SIGNATURE_TYPE],
 });
 
 const CODE_LOCATION = process.cwd();
-const PORT = argv['port'] || process.env.PORT || '8080';
+const PORT =
+  argv[ENV_VARIABLE.PORT] || process.env[ENV_VARIABLE.PORT] || '8080';
 const FUNCTION_TARGET =
-  argv['function-target'] || process.env.FUNCTION_TARGET || 'function';
+  argv[FLAG.TARGET] || process.env[ENV_VARIABLE.TARGET] || 'function';
 
 const FUNCTION_SIGNATURE_TYPE_STRING =
-  argv['function-signature-type'] ||
-  process.env.FUNCTION_SIGNATURE_TYPE ||
-  'http';
+  argv[FLAG.SIGNATURE_TYPE] || process.env.FUNCTION_SIGNATURE_TYPE || 'http';
 const FUNCTION_SIGNATURE_TYPE =
   FunctionSignatureType[
     FUNCTION_SIGNATURE_TYPE_STRING.toUpperCase() as keyof typeof FunctionSignatureType

--- a/src/invoker.ts
+++ b/src/invoker.ts
@@ -23,8 +23,8 @@
 import * as bodyParser from 'body-parser';
 import * as domain from 'domain';
 import * as express from 'express';
-import * as onFinished from 'on-finished';
 import * as http from 'http';
+import * as onFinished from 'on-finished';
 
 // HTTP header field that is added to Worker response to signalize problems with
 // executing the client function.
@@ -123,7 +123,7 @@ declare global {
   }
 }
 
-export enum FunctionSignatureType {
+export enum SignatureType {
   HTTP,
   EVENT,
 }
@@ -136,9 +136,9 @@ export enum FunctionSignatureType {
  */
 function isHttpFunction(
   fn: HandlerFunction,
-  functionSignatureType: FunctionSignatureType
+  functionSignatureType: SignatureType
 ): fn is HttpFunction {
-  return functionSignatureType === FunctionSignatureType.HTTP;
+  return functionSignatureType === SignatureType.HTTP;
 }
 
 /**
@@ -477,7 +477,7 @@ function wrapEventFunction(
 function registerFunctionRoutes(
   app: express.Application,
   userFunction: HandlerFunction,
-  functionSignatureType: FunctionSignatureType
+  functionSignatureType: SignatureType
 ) {
   if (isHttpFunction(userFunction!, functionSignatureType)) {
     app.use('/*', (req, res, next) => {
@@ -548,7 +548,7 @@ export class ErrorHandler {
  */
 export function getServer(
   userFunction: HandlerFunction,
-  functionSignatureType: FunctionSignatureType
+  functionSignatureType: SignatureType
 ): http.Server {
   // App to use for function executions.
   const app = express();

--- a/test/invoker.ts
+++ b/test/invoker.ts
@@ -13,10 +13,9 @@
 // limitations under the License.
 
 import * as assert from 'assert';
-import * as supertest from 'supertest';
 import * as express from 'express';
-
 import * as invoker from '../src/invoker';
+import * as supertest from 'supertest';
 
 describe('loading function', () => {
   it('should load the function', () => {
@@ -35,7 +34,7 @@ describe('request to HTTP function', () => {
       (req: express.Request, res: express.Response) => {
         res.send(req.body.text.toUpperCase());
       },
-      invoker.FunctionSignatureType.HTTP
+      invoker.SignatureType.HTTP
     );
     return supertest(server)
       .post('/')
@@ -106,7 +105,7 @@ describe('GCF event request to event function', () => {
       const server = invoker.getServer((data: {}, context: invoker.Context) => {
         receivedData = data;
         receivedContext = context as invoker.CloudFunctionsContext;
-      }, invoker.FunctionSignatureType.EVENT);
+      }, invoker.SignatureType.EVENT);
       await supertest(server)
         .post('/')
         .send(test.body)
@@ -169,7 +168,7 @@ describe('CloudEvents request to event function', () => {
       const server = invoker.getServer((data: {}, context: invoker.Context) => {
         receivedData = data;
         receivedContext = context as invoker.CloudEventsContext;
-      }, invoker.FunctionSignatureType.EVENT);
+      }, invoker.SignatureType.EVENT);
       await supertest(server)
         .post('/')
         .set(test.headers)


### PR DESCRIPTION
Fixes #4.
- Removes redundant `function` from CLI/env vars for `target` and `signature-type`
- Updates docs
- Moves string literals into constants to reduce renaming multiple pieces of code and clearly define the library interface in 1 place.