### PR TITLE
docs(README): Replace --target with --function-target

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ exports.helloWorld = (req, res) => {
 Run the following command:
 
 ```sh
-npx @google-cloud/functions-framework --target=helloWorld
+npx @google-cloud/functions-framework --function-target=helloWorld
 ```
 
 Open http://localhost:8080/ in your browser and see *Hello, World*.
@@ -91,7 +91,7 @@ command-line arguments:
 
 ```js
   "scripts": {
-    "start": "functions-framework --target=helloWorld"
+    "start": "functions-framework --function-target=helloWorld"
   }
 ```
 
@@ -145,7 +145,7 @@ ignored.
 Command-line flag         | Environment variable      | Description
 ------------------------- | ------------------------- | -----------
 `--port`                    | `PORT`                    | The port on which the Functions Framework listens for requests. Default: `8080`
-`--target`         | `FUNCTION_TARGET`         | The name of the exported function to be invoked in response to requests. Default: `function`
+`--function-target`         | `FUNCTION_TARGET`         | The name of the exported function to be invoked in response to requests. Default: `function`
 `--signature-type` | `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function. Default: `http`; accepted values: `http` or `event`
 
 You can set command-line flags in your `package.json` via the `start` script.
@@ -153,7 +153,7 @@ For example:
 
 ```js
   "scripts": {
-    "start": "functions-framework --target=helloWorld"
+    "start": "functions-framework --function-target=helloWorld"
   }
 ```
 


### PR DESCRIPTION
Otherwise it errors:

```
$ npx @google-cloud/functions-framework --target=helloWorld
Function 'function' is not defined in the provided module.
Did you specify the correct target function to execute?
Could not load the function, shutting down.
```