### PR TITLE
Create `docs/` folder/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# Functions Frameowork Docs
+
+This folder contains advanced guides for the Functions Framework
+
+> Note: There are no guides yet.


### PR DESCRIPTION
Create a `docs/` folder/README for guides that shouldn't clutter up the main README of this repo.