### PR TITLE
fix: Adds CLI help flag. Fixes #31

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,16 @@ if (SIGNATURE_TYPE === undefined) {
   process.exit(1);
 }
 
+// CLI Help Flag
+if (process.argv[2] === '-h' || process.argv[2] === '--help') {
+  console.error(
+`Example usage:
+  functions-framework --target=helloWorld --port=8080
+Documentation:
+  https://github.com/GoogleCloudPlatform/functions-framework-nodejs`);
+  process.exit(1);
+}
+
 const USER_FUNCTION = getUserFunction(CODE_LOCATION, TARGET);
 if (!USER_FUNCTION) {
   console.error('Could not load the function, shutting down.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,10 +76,11 @@ if (SIGNATURE_TYPE === undefined) {
 // CLI Help Flag
 if (process.argv[2] === '-h' || process.argv[2] === '--help') {
   console.error(
-`Example usage:
+    `Example usage:
   functions-framework --target=helloWorld --port=8080
 Documentation:
-  https://github.com/GoogleCloudPlatform/functions-framework-nodejs`);
+  https://github.com/GoogleCloudPlatform/functions-framework-nodejs`
+  );
   process.exit(1);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ if (process.argv[2] === '-h' || process.argv[2] === '--help') {
 Documentation:
   https://github.com/GoogleCloudPlatform/functions-framework-nodejs`
   );
-  process.exit(1);
+  process.exit(0);
 }
 
 const USER_FUNCTION = getUserFunction(CODE_LOCATION, TARGET);


### PR DESCRIPTION
Adds a CLI help flag (-h, --help). Fixes #31.

## Example

```sh
granttimmerman @ ~/Documents/trash/testff
❤ functions-framework --help
Usage:
  functions-framework --target=helloWorld --port=8080
Documentation:
  https://github.com/GoogleCloudPlatform/functions-framework-nodejs
```

CC: @grayside