### PR TITLE
Add todo/reference to Local Debug thread

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,4 @@ This directory contains advanced docs around the Functions Framework.
 - TODO: Run Multiple Cloud Functions [#23](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/23)
 - TODO: Pub/Sub Trigger [#37](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/37)
 - TODO: Deploy to Cloud Run [#28](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/28)
+- TODO: Local Debug [#15](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/15)


### PR DESCRIPTION
Simple change - added a new item to the TODO list with reference to Local Debug thread. That should help in preparing complete documentation later on.