### PR TITLE
Add a source flag/env option to add flexibility to execution path

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Command-line flag         | Environment variable      | Description
 `--port`                    | `PORT`                    | The port on which the Functions Framework listens for requests. Default: `8080`
 `--target`         | `FUNCTION_TARGET`         | The name of the exported function to be invoked in response to requests. Default: `function`
 `--signature-type` | `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function. Default: `http`; accepted values: `http` or `event`
+`--source`         | `SOURCE`         | The path of your project directory where you want to start. Functions framework always look only at root path, setting this option will look for your function in any other folder. Default: `/`
 
 You can set command-line flags in your `package.json` via the `start` script.
 For example:

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Command-line flag         | Environment variable      | Description
 `--port`                    | `PORT`                    | The port on which the Functions Framework listens for requests. Default: `8080`
 `--target`         | `FUNCTION_TARGET`         | The name of the exported function to be invoked in response to requests. Default: `function`
 `--signature-type` | `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function. Default: `http`; accepted values: `http` or `event`
-`--source`         | `SOURCE`         | The path of your project directory where you want to start. Functions framework always look only at root path, setting this option will look for your function in any other folder. Default: `/`
+`--source`         | `FUNCTION_SOURCE`         | The path of your project directory where you want to start. Functions framework always look only at root path, setting this option will look for your function in any other folder. Default: `/`
 
 You can set command-line flags in your `package.json` via the `start` script.
 For example:

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@
 //     unmarshalled from an incoming request.
 
 import * as minimist from 'minimist';
+import { resolve } from 'path';
 
 import {
   ErrorHandler,
@@ -41,6 +42,7 @@ const FLAG = {
   PORT: 'port',
   TARGET: 'target',
   SIGNATURE_TYPE: 'signature-type', // dash
+  SOURCE: 'source',
 };
 
 // Supported environment variables
@@ -48,6 +50,7 @@ const ENV = {
   PORT: 'PORT',
   TARGET: 'FUNCTION_TARGET',
   SIGNATURE_TYPE: 'FUNCTION_SIGNATURE_TYPE', // underscore
+  SOURCE: 'SOURCE',
 };
 
 enum NodeEnv {
@@ -58,7 +61,10 @@ const argv = minimist(process.argv, {
   string: [FLAG.PORT, FLAG.TARGET, FLAG.SIGNATURE_TYPE],
 });
 
-const CODE_LOCATION = process.cwd();
+const CODE_LOCATION = resolve(
+  process.cwd(),
+  argv[FLAG.SOURCE] || process.env[ENV.SOURCE] || '/'
+);
 const PORT = argv[FLAG.PORT] || process.env[ENV.PORT] || '8080';
 const TARGET = argv[FLAG.TARGET] || process.env[ENV.TARGET] || 'function';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ const ENV = {
   PORT: 'PORT',
   TARGET: 'FUNCTION_TARGET',
   SIGNATURE_TYPE: 'FUNCTION_SIGNATURE_TYPE', // underscore
-  SOURCE: 'SOURCE',
+  SOURCE: 'FUNCTION_SOURCE',
 };
 
 enum NodeEnv {


### PR DESCRIPTION
Hey,

In my use of Cloud Functions, i've encountered with the situation of using different folders to hold my functions, so this will be helpful for me and any others.