### PR TITLE
Docs: Add Docker Tutorial Doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules/
 build/
-/docs/
 .coverage/
 npm-debug.log
 .nyc_output

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,10 @@
 
 This directory contains advanced docs around the Functions Framework.
 
+- [Running and Deploying Docker Containers](docker.md)
+
+## TODO Docs
+
 - TODO: Run Multiple Cloud Functions [#23](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/23)
 - TODO: Pub/Sub Trigger [#37](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/37)
-- TODO: Deploy to Cloud Run [#28](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/28)
 - TODO: Local Debug [#15](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/15)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -23,7 +23,7 @@ CMD [ "npm", "start" ]
 Start the container locally by running `docker build` and `docker run`:
 
 ```sh
-docker build -t helloworld . && docker run -p 8080:8080 -it helloworld
+docker build -t helloworld . && docker run --rm -p 8080:8080 helloworld
 ```
 
 Send requests to this function using `curl` from another terminal window:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -35,7 +35,7 @@ curl localhost:8080
 
 ## Deploy a Container
 
-You can deploy your containerized function to Cloud Run or any Knative-based environment by following the [Cloud Run quickstart](https://cloud.google.com/run/docs/quickstarts/build-and-deploy).
+You can deploy your containerized function to Cloud Run by following the [Cloud Run quickstart](https://cloud.google.com/run/docs/quickstarts/build-and-deploy).
 
 Use the `docker` and `gcloud` CLIs to build and deploy a container to Cloud Run, replacing the project id `$GOOGLE_CLOUD_PROJECT` and image name `helloworld`:
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,48 @@
+# Run a Function in a Docker Container
+
+To run your function in a container, create a `Dockerfile` with the following contents:
+
+```Dockerfile
+# Use the official Node.js 10 image.
+# https://hub.docker.com/_/node
+FROM node:10
+# Create and change to the app directory.
+WORKDIR /usr/src/app
+# Copy application dependency manifests to the container image.
+# A wildcard is used to ensure both package.json AND package-lock.json are copied.
+# Copying this separately prevents re-running npm install on every code change.
+COPY package.json package*.json ./
+# Install production dependencies.
+RUN npm install --only=production
+# Copy local code to the container image.
+COPY . .
+# Run the web service on container startup.
+CMD [ "npm", "start" ]
+```
+
+Start the container locally by running `docker build` and `docker run`:
+
+```sh
+docker build -t helloworld . && docker run -p 8080:8080 -it helloworld
+```
+
+Send requests to this function using `curl` from another terminal window:
+
+```sh
+curl localhost:8080
+# Output: Hello, World
+```
+
+## Deploy a Container
+
+You can deploy your containerized function to Cloud Run or any Knative-based environment by following the [Cloud Run quickstart](https://cloud.google.com/run/docs/quickstarts/build-and-deploy).
+
+Use the `docker` and `gcloud` CLIs to build and deploy a container to Cloud Run, replacing the project id `$GOOGLE_CLOUD_PROJECT` and image name `helloworld`:
+
+```sh
+docker build -t gcr.io/$GOOGLE_CLOUD_PROJECT/helloworld .
+docker push gcr.io/$GOOGLE_CLOUD_PROJECT/helloworld
+gcloud beta run deploy helloworld --image gcr.io/$GOOGLE_CLOUD_PROJECT/helloworld --region us-central1
+```
+
+If you want even more control over the environment, you can [deploy your container image to Cloud Run on GKE](https://cloud.google.com/run/docs/quickstarts/prebuilt-deploy-gke). With Cloud Run on GKE, you can run your function on a GKE cluster, which gives you additional control over the environment (including use of GPU-based instances, longer timeouts and more).

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -33,6 +33,14 @@ curl localhost:8080
 # Output: Hello, World
 ```
 
+## Configure gcloud
+
+To use Docker with gcloud, (configure the Docker credential helper](https://cloud.google.com/container-registry/docs/advanced-authentication):
+
+```sh
+gcloud auth configure-docker
+```
+
 ## Deploy a Container
 
 You can deploy your containerized function to Cloud Run by following the [Cloud Run quickstart](https://cloud.google.com/run/docs/quickstarts/build-and-deploy).


### PR DESCRIPTION
Modifies PR to add instructions on how to deploy the FF to Cloud Run:
See https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/28
R: @grayside