### PR TITLE
Add instructions for local debugging

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ exports.helloWorld = (req, res) => {
 npm install @google-cloud/functions-framework
 ```
 
-3. Launch the Functions Framework and attach a debugger:
+3. Run `node`, enable the inspector and run the Functions Framework (specifying the your target function):
 
 ```sh
 node --inspect node_modules/@google-cloud/functions-framework --target=helloWorld

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ exports.helloWorld = (req, res) => {
 npm install @google-cloud/functions-framework
 ```
 
-3. Run `node`, enable the inspector and run the Functions Framework (specifying the your target function):
+3. Run `node`, enable the inspector and run the Functions Framework:
 
 ```sh
 node --inspect node_modules/@google-cloud/functions-framework --target=helloWorld

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ This directory contains advanced docs around the Functions Framework.
 
 The Functions Framework works with standard tooling that you might use when writing a function for a Node.js environment. You can attach a debugger to your function by following these steps.
 
-1. Write a Node.js function:
+1. Write an `index.js` file containing your Node.js function:
 
 ```js
 exports.helloWorld = (req, res) => {

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,4 +5,35 @@ This directory contains advanced docs around the Functions Framework.
 - TODO: Run Multiple Cloud Functions [#23](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/23)
 - TODO: Pub/Sub Trigger [#37](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/37)
 - TODO: Deploy to Cloud Run [#28](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/28)
-- TODO: Local Debug [#15](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/15)
+
+## Debugging functions
+
+The Functions Framework works with standard tooling that you might use when writing a function for a Node.js environment. You can attach a debugger to your function by following these steps.
+
+1. Write a Node.js function:
+
+```js
+exports.helloWorld = (req, res) => {
+  res.send('Hello, World');
+};
+```
+
+2. Install the Functions Framework:
+
+```sh
+npm install @google-cloud/functions-framework
+```
+
+3. Launch the Functions Framework and attach a debugger:
+
+```sh
+node --inspect node_modules/@google-cloud/functions-framework --target=helloWorld
+...
+Debugger listening on ws://127.0.0.1:9229/5f57f5e9-ea4b-43ce-be1d-6e9b838ade4a
+For help see https://nodejs.org/en/docs/inspector
+Serving function...
+Function: helloWorld
+URL: http://localhost:8080/
+```
+
+You can now use an IDE or other tooling to add breakpoints, step through your code and debug your function.


### PR DESCRIPTION
Adds steps to attach a debugger to your function running locally.

Addresses:

- https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/47
- https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/15