### PR TITLE
Adding null check in catch block

### DIFF
--- a/src/invoker.ts
+++ b/src/invoker.ts
@@ -193,7 +193,7 @@ export function getUserFunction(
   } catch (ex) {
     let additionalHint: string;
     // TODO: this should be done based on ex.code rather than string matching.
-    if (ex.stack.includes('Cannot find module')) {
+    if (ex.stack && ex.stack.includes('Cannot find module')) {
       additionalHint =
         'Did you list all required modules in the package.json ' +
         'dependencies?\n';


### PR DESCRIPTION
During our cloud function deployment we encountered error:
```
Deployment failure:
Function failed on loading user code. Error message: /srv/functions/node_modules/@google-cloud/functions-framework/build/src/invoker.js:89
        if (ex.stack.includes('Cannot find module')) {
                     ^
TypeError: Cannot read property 'includes' of undefined
    at Object.getUserFunction (/srv/functions/node_modules/@google-cloud/functions-framework/build/src/invoker.js:89:22)
    at Object.<anonymous> (/srv/functions/node_modules/@google-cloud/functions-framework/build/src/index.js:67:33)
    at Module._compile (internal/modules/cjs/loader.js:701:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
    at Module.load (internal/modules/cjs/loader.js:600:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
    at Function.Module._load (internal/modules/cjs/loader.js:531:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:754:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)
```
The ex.stack can be null, so I added tiny null check.