### PR TITLE
Change the default function directory to the current working directory instead of root

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Command-line flag         | Environment variable      | Description
 `--port`                    | `PORT`                    | The port on which the Functions Framework listens for requests. Default: `8080`
 `--target`         | `FUNCTION_TARGET`         | The name of the exported function to be invoked in response to requests. Default: `function`
 `--signature-type` | `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function. Default: `http`; accepted values: `http` or `event`
-`--source`         | `FUNCTION_SOURCE`         | The path of your project directory where you want to start. Functions framework always look only at root path, setting this option will look for your function in any other folder. Default: `/`
+`--source`         | `FUNCTION_SOURCE`         | The path to the directory of your function. Default: `cwd` (the current working directory)
 
 You can set command-line flags in your `package.json` via the `start` script.
 For example:

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ const argv = minimist(process.argv, {
 
 const CODE_LOCATION = resolve(
   process.cwd(),
-  argv[FLAG.SOURCE] || process.env[ENV.SOURCE] || '/'
+  argv[FLAG.SOURCE] || process.env[ENV.SOURCE]
 );
 const PORT = argv[FLAG.PORT] || process.env[ENV.PORT] || '8080';
 const TARGET = argv[FLAG.TARGET] || process.env[ENV.TARGET] || 'function';


### PR DESCRIPTION
This was the default before introducing the --source flag. Making root ('/') the default breaks existing projects if users don't specify --source.