### PR TITLE
fix: use empty string path when function source is not specified

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ const argv = minimist(process.argv, {
 
 const CODE_LOCATION = resolve(
   process.cwd(),
-  argv[FLAG.SOURCE] || process.env[ENV.SOURCE]
+  argv[FLAG.SOURCE] || process.env[ENV.SOURCE] || ''
 );
 const PORT = argv[FLAG.PORT] || process.env[ENV.PORT] || '8080';
 const TARGET = argv[FLAG.TARGET] || process.env[ENV.TARGET] || 'function';

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,6 @@ const argv = minimist(process.argv, {
 });
 
 const CODE_LOCATION = resolve(
-  process.cwd(),
   argv[FLAG.SOURCE] || process.env[ENV.SOURCE] || ''
 );
 const PORT = argv[FLAG.PORT] || process.env[ENV.PORT] || '8080';


### PR DESCRIPTION
I removed `'/'` from `CODE_LOCATION` that set the default function directory to root in commit #77. This causes this error in 1.3.0,
```
npx @google-cloud/functions-framework --target=helloWorld
The "path" argument must be of type string. Received type undefined
```

When `--source` flag and `FUNCTION_SOURCE` env var are not specified, one of the 'path' arguments in `resolve()` is undefined. This causes the error above.

I've added empty string as an argument in the case above.

fixes issue #89 