### PR TITLE
Changed curl command to include json content-type

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,7 @@ curl -d "@mockPubsub.json" -X POST \
   -H "Ce-Specversion: true" \
   -H "Ce-Source: true" \
   -H "Ce-Id: true" \
+  -H “Content-Type: application/json” \
   http://localhost:8080
 ```
 


### PR DESCRIPTION
To be able to parse the event properly, content type must be set. This is at least true for my environment.