### PR TITLE
docs: add video about FF

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ curl http://my-url
 All without needing to worry about writing an HTTP server or complicated request
 handling logic.
 
+> Watch a video about the Node Functions Framework: https://youtu.be/yMEcyAkTliU?t=912
+
 # Features
 
 *   Spin up a local development server for quick testing

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ curl http://my-url
 All without needing to worry about writing an HTTP server or complicated request
 handling logic.
 
-> Watch [this video](https://youtu.be/yMEcyAkTliU?t=912) to learn about the Node Functions Framework.
+> Watch [this video](https://youtu.be/yMEcyAkTliU?t=912) to learn more about the Node Functions Framework.
 
 # Features
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ curl http://my-url
 All without needing to worry about writing an HTTP server or complicated request
 handling logic.
 
-> Watch a video about the Node Functions Framework: https://youtu.be/yMEcyAkTliU?t=912
+> Watch [this video](https://youtu.be/yMEcyAkTliU?t=912) to learn about the Node Functions Framework.
 
 # Features
 


### PR DESCRIPTION
Adds a useful video explaining the Functions Framework to the repo's README.
Fixes #73.