### PR TITLE
Add cookieParser middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/functions-framework",
-  "version": "1.2.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -41,6 +41,15 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/cookie-parser": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.2.tgz",
+      "integrity": "sha512-uwcY8m6SDQqciHsqcKDGbo10GdasYsPCYkH3hVegj9qAah6pX5HivOnOuI3WYmyQMnOATV39zv/Ybs0bC/6iVg==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
       }
     },
     "@types/cookiejar": {
@@ -472,6 +481,22 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+    },
+    "cookie-parser": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
+      "integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        }
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "types": "build/src/invoker.d.ts",
   "dependencies": {
     "body-parser": "^1.18.3",
+    "cookie-parser": "^1.4.4",
     "express": "^4.16.4",
     "minimist": "^1.2.0",
     "on-finished": "^2.3.0"
@@ -35,6 +36,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/body-parser": "^1.17.0",
+    "@types/cookie-parser": "^1.4.2",
     "@types/express": "^4.16.1",
     "@types/minimist": "^1.2.0",
     "@types/mocha": "^5.2.6",

--- a/src/invoker.ts
+++ b/src/invoker.ts
@@ -21,6 +21,7 @@
 //     functions with HTTP trigger).
 
 import * as bodyParser from 'body-parser';
+import * as cookieParser from 'cookie-parser';
 import * as domain from 'domain';
 import * as express from 'express';
 import * as http from 'http';
@@ -568,6 +569,8 @@ export function getServer(
   // MUST be last in the list of body parsers as subsequent parsers will be
   // skipped when one is matched.
   app.use(bodyParser.raw(rawBodySavingOptions));
+
+  app.use(cookieParser());
 
   registerFunctionRoutes(app, userFunction, functionSignatureType);
 


### PR DESCRIPTION
You can already set cookies, but they are not parsed into the Request without this middleware.