### PR TITLE
Fix double quotation from full-width character

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -78,7 +78,7 @@ curl -d "@mockPubsub.json" -X POST \
   -H "Ce-Specversion: true" \
   -H "Ce-Source: true" \
   -H "Ce-Id: true" \
-  -H “Content-Type: application/json” \
+  -H "Content-Type: application/json" \
   http://localhost:8080
 ```
 


### PR DESCRIPTION
So far, Just only convert from full-width double quotation (`”`) to single-width double quotation (`"`) .