### PR TITLE
Added GCP local parity

### DIFF
--- a/src/invoker.ts
+++ b/src/invoker.ts
@@ -445,6 +445,21 @@ function wrapEventFunction(
       context.data = undefined;
       delete context.data;
     }
+    // Populating data for behavior compliant with parameter settings of Cloud PubSub
+    // https://cloud.google.com/functions/docs/writing/background#function_parameters
+    if (!data && event.message) {
+      data = event.message!.data;
+      if (!context.eventId) {
+        context.eventId = event.message.messageId;
+      }
+      if (!context.timestamp) {
+        context.timestamp =
+          event.message.publishTime || new Date().toISOString();
+      }
+      if (!context.eventType) {
+        context.eventType = 'google.pubsub.topic.publish';
+      }
+    }
     // Callback style if user function has more than 2 arguments.
     if (userFunction!.length > 2) {
       const fn = userFunction as EventFunctionWithCallback;


### PR DESCRIPTION
There is a well-known bug with this framework documented in #96 and #41. The basic problem is that Cloud PubSub (at least local version) does not actually respect [Cloud Event Specs](https://github.com/cloudevents/spec/blob/v1.0/spec.md#message) in respect to binary vs structured mode by providing no respective HTTP (CE-) headers. 

The purpose of this framework is to enable local testing of GCP Cloud function, which is not currently not fulfilled for background function use case. Even example provided in docs would not currently work

I tried to carefully implement it and only do changes to the current logic only when it is absolutely necessary. I have also added a test to show a use case. For field specifications, I followed GCP documentation on [background functions](https://cloud.google.com/functions/docs/writing/background#function_parameters.)