### PR TITLE
fix: handle SIGINT in ErrorHandler

### DIFF
--- a/src/invoker.ts
+++ b/src/invoker.ts
@@ -535,9 +535,12 @@ export class ErrorHandler {
       logAndSendError(new Error(`Process exited with code ${code}`), latestRes);
     });
 
-    process.on('SIGTERM', () => {
-      this.server.close(() => {
-        process.exit();
+    ['SIGINT', 'SIGTERM'].forEach(signal => {
+      process.on(signal as NodeJS.Signals, () => {
+        console.log(`Received ${signal}`);
+        this.server.close(() => {
+          process.exit();
+        });
       });
     });
   }


### PR DESCRIPTION
Currently, when running the Functions Framework in a Docker container by running `docker run`, one cannot stop the running container with Ctrl+C. This is because the Functions Framework doesn't handle SIGINT in the ErrorHandler. This change handles SIGINT in the similar fashion as SIGTERM i.e. close the web server and exit the process.