### PR TITLE
fix: do not err on process exit

### DIFF
--- a/src/invoker.ts
+++ b/src/invoker.ts
@@ -259,7 +259,7 @@ export class ErrorHandler {
     });
 
     process.on('exit', code => {
-      logAndSendError(new Error(`Process exited with code ${code}`), latestRes);
+      console.log(`Process exited with code ${code}`);
     });
 
     ['SIGINT', 'SIGTERM'].forEach(signal => {

--- a/src/invoker.ts
+++ b/src/invoker.ts
@@ -258,7 +258,7 @@ export class ErrorHandler {
       logAndSendError(err, latestRes, killInstance);
     });
 
-    process.on('exit', code => {
+    process.on('SIGINT', code => {
       console.log(`Process exited with code ${code}`);
     });
 


### PR DESCRIPTION
Fixes: #22 #143

This change the behavior the process exit event handler.
I don't know exactly why we have a `latestRes` modification here or if it's needed. I would assume a process exit does not need to send the latest HTTP response as an exit would not naturally happen.

## Before

```sh
Serving function...
Function: function
URL: http://localhost:8080/
^CReceived SIGINT
Error: Process exited with code 0
    at process.<anonymous> (<folder>/node_modules/@google-cloud/functions-framework/build/src/invoker.js:396:29)
    at process.emit (events.js:203:13)
    at process.EventEmitter.emit (domain.js:471:20)
    at process.exit (internal/process/per_thread.js:158:15)
    at Server.<anonymous> (<folder>/node_modules/@google-cloud/functions-framework/build/src/invoker.js:402:29)
    at Object.onceWrapper (events.js:291:20)
    at Server.emit (events.js:203:13)
    at Server.EventEmitter.emit (domain.js:471:20)
    at emitCloseNT (net.js:1572:8)
    at processTicksAndRejections (internal/process/task_queues.js:77:11)
```

## After

```sh
Serving function...
Function: function
URL: http://localhost:8080/
^CReceived SIGINT
Process exited with code 0
```