### PR TITLE
chore: make renovate not update as often

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,7 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "pinVersions": false,
+  "schedule": "on monday"
 }


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/168

I'm not sure exactly how to make PRs only bump versions if minor or major (rather than patch), but this should help a bit.