### PR TITLE
chore: bump ts version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2646,9 +2646,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
-      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "unique-string": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "mocha": "6.1.4",
     "power-assert": "1.6.1",
     "supertest": "3.4.2",
-    "typescript": "3.5.1"
+    "typescript": "^3.9.7"
   }
 }


### PR DESCRIPTION
Manually bumps TS version.
Needed for https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/160