### PR TITLE
fix: do not send error when error code is fine

### DIFF
--- a/src/invoker.ts
+++ b/src/invoker.ts
@@ -314,7 +314,9 @@ export class ErrorHandler {
     });
 
     process.on('exit', code => {
-      logAndSendError(new Error(`Process exited with code ${code}`), latestRes);
+      if (code) {
+        logAndSendError(new Error(`Process exited with code ${code}`), latestRes);
+      }
     });
 
     ['SIGINT', 'SIGTERM'].forEach(signal => {

--- a/src/invoker.ts
+++ b/src/invoker.ts
@@ -314,13 +314,11 @@ export class ErrorHandler {
     });
 
     process.on('exit', code => {
-      if (code) {
-        sendCrashResponse({
-          err: new Error(`Process exited with code ${code}`),
-          res: latestRes,
-          silent: true,
-        });
-      }
+      sendCrashResponse({
+        err: new Error(`Process exited with code ${code}`),
+        res: latestRes,
+        silent: code === 0,
+      });
     });
 
     ['SIGINT', 'SIGTERM'].forEach(signal => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -22,13 +22,21 @@ import {FUNCTION_STATUS_HEADER_FIELD} from './types';
  * @param res Express response object.
  * @param callback A function to be called synchronously.
  */
-export function logAndSendError(
+export function sendCrashResponse({
+  err,
+  res,
+  callback,
+  silent = false,
+}: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  err: Error | any,
-  res: express.Response | null,
-  callback?: Function
-) {
-  console.error(err.stack || err);
+  err: Error | any;
+  res: express.Response | null;
+  callback?: Function;
+  silent?: boolean;
+}) {
+  if (!silent) {
+    console.error(err.stack || err);
+  }
 
   // If user function has already sent response headers, the response with
   // error message cannot be sent. This check is done inside the callback,


### PR DESCRIPTION
Doesn't log assuming an error on process.exit. Keeps same functionality.
Tested locally.

```
 npx @google-cloud/functions-framework --target=helloWorld

Serving function...
Function: helloWorld
URL: http://localhost:8080/
^CReceived SIGINT
```

Not sure about upstream impact.