### PR TITLE
Don't call the function after a 404 on /{robots.txt,favicon.ico}

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/functions-framework",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/invoker.ts
+++ b/src/invoker.ts
@@ -123,8 +123,8 @@ function makeHttpHandler(execute: HttpFunction): express.RequestHandler {
 }
 
 /**
- * Wraps cloudevent function (or cloudevent function with callback) in HTTP function
- * signature.
+ * Wraps cloudevent function (or cloudevent function with callback) in HTTP
+ * function signature.
  * @param userFunction User's function.
  * @return HTTP function which wraps the provided event function.
  */
@@ -251,9 +251,10 @@ function registerFunctionRoutes(
   functionSignatureType: SignatureType
 ) {
   if (functionSignatureType === SignatureType.HTTP) {
-    app.use('/favicon.ico|/robots.txt', (req, res, next) => {
-      res.sendStatus(404);
-      next();
+    app.use('/favicon.ico|/robots.txt', (req, res) => {
+      // Neither crawlers nor browsers attempting to pull the icon find the body
+      // contents particularly useful, so we send nothing in the response body.
+      res.status(404).send(null);
     });
 
     app.use('/*', (req, res, next) => {
@@ -372,8 +373,8 @@ export function getServer(
     req.rawBody = buf;
   }
 
-  // Set limit to a value larger than 32MB, which is maximum limit of higher level
-  // layers anyway.
+  // Set limit to a value larger than 32MB, which is maximum limit of higher
+  // level layers anyway.
   const requestLimit = '1024mb';
   const defaultBodySavingOptions = {
     limit: requestLimit,

--- a/test/invoker.ts
+++ b/test/invoker.ts
@@ -24,6 +24,7 @@ describe('request to HTTP function', () => {
     path: string;
     text: string;
     status: number;
+    callCount: number;
   }
 
   const testData: TestData[] = [
@@ -32,41 +33,48 @@ describe('request to HTTP function', () => {
       path: '/',
       text: 'HELLO',
       status: 200,
+      callCount: 1,
     },
     {
       name: 'simple path',
       path: '/foo',
       text: 'HELLO',
       status: 200,
+      callCount: 1,
     },
     {
       name: 'with favicon.ico',
       path: '/favicon.ico',
-      text: 'Not Found',
+      text: '',
       status: 404,
+      callCount: 0,
     },
     {
       name: 'with robots.txt',
       path: '/robots.txt',
-      text: 'Not Found',
+      text: '',
       status: 404,
+      callCount: 0,
     },
   ];
 
   testData.forEach(test => {
-    it(`should return transformed body: ${test.name}`, () => {
+    it(`should return transformed body: ${test.name}`, async () => {
+      var callCount = 0;
       const server = invoker.getServer(
         (req: express.Request, res: express.Response) => {
+          ++callCount;
           res.send(req.body.text.toUpperCase());
         },
         invoker.SignatureType.HTTP
       );
-      return supertest(server)
+      await supertest(server)
         .post(test.path)
         .send({ text: 'hello' })
         .set('Content-Type', 'application/json')
         .expect(test.text)
         .expect(test.status);
+      assert.strictEqual(callCount, test.callCount);
     });
   });
 });


### PR DESCRIPTION
Other changes:
 * Send an empty response body for the same with the 404, since   these URLs are not intended for human consumption.
 * Add an invocation count assertion to the test to confirm that   these URLs do not in fact result in the function call.
 * Accept npm's lockfile update of this own package version.
 * Nit: wrap long comments at 80 characters.

Fixes: #191