### PR TITLE
refactor: split invoker and router

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,10 +33,10 @@
 
 import * as minimist from 'minimist';
 import {resolve} from 'path';
-
 import {getUserFunction} from './loader';
-
-import {ErrorHandler, SignatureType, getServer} from './invoker';
+import {ErrorHandler} from './invoker';
+import {getServer} from './server';
+import {SignatureType} from './types';
 
 // Supported command-line flags
 const FLAG = {

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,77 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as express from 'express';
+import * as onFinished from 'on-finished';
+import {HandlerFunction} from './functions';
+import {SignatureType} from './types';
+import {
+  makeHttpHandler,
+  wrapEventFunction,
+  wrapCloudEventFunction,
+} from './invoker';
+import {
+  HttpFunction,
+  EventFunction,
+  EventFunctionWithCallback,
+  CloudEventFunction,
+  CloudEventFunctionWithCallback,
+} from './functions';
+
+/**
+ * Registers handler functions for route paths.
+ * @param app Express application object.
+ * @param userFunction User's function.
+ * @param functionSignatureType Type of user's function signature.
+ */
+export function registerFunctionRoutes(
+  app: express.Application,
+  userFunction: HandlerFunction,
+  functionSignatureType: SignatureType
+) {
+  if (functionSignatureType === SignatureType.HTTP) {
+    app.use('/favicon.ico|/robots.txt', (req, res) => {
+      // Neither crawlers nor browsers attempting to pull the icon find the body
+      // contents particularly useful, so we send nothing in the response body.
+      res.status(404).send(null);
+    });
+
+    app.use('/*', (req, res, next) => {
+      onFinished(res, (err, res) => {
+        res.locals.functionExecutionFinished = true;
+      });
+      next();
+    });
+
+    app.all('/*', (req, res, next) => {
+      const handler = makeHttpHandler(userFunction as HttpFunction);
+      handler(req, res, next);
+    });
+  } else if (functionSignatureType === SignatureType.EVENT) {
+    app.post('/*', (req, res, next) => {
+      const wrappedUserFunction = wrapEventFunction(
+        userFunction as EventFunction | EventFunctionWithCallback
+      );
+      const handler = makeHttpHandler(wrappedUserFunction);
+      handler(req, res, next);
+    });
+  } else {
+    app.post('/*', (req, res, next) => {
+      const wrappedUserFunction = wrapCloudEventFunction(
+        userFunction as CloudEventFunction | CloudEventFunctionWithCallback
+      );
+      const handler = makeHttpHandler(wrappedUserFunction);
+      handler(req, res, next);
+    });
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,99 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as bodyParser from 'body-parser';
+import * as express from 'express';
+import * as http from 'http';
+import {HandlerFunction} from './functions';
+import {SignatureType} from './types';
+import {setLatestRes} from './invoker';
+import {registerFunctionRoutes} from './router';
+
+/**
+ * Creates and configures an Express application and returns an HTTP server
+ * which will run it.
+ * @param userFunction User's function.
+ * @param functionSignatureType Type of user's function signature.
+ * @return HTTP server.
+ */
+export function getServer(
+  userFunction: HandlerFunction,
+  functionSignatureType: SignatureType
+): http.Server {
+  // App to use for function executions.
+  const app = express();
+
+  // Express middleware
+
+  // Set request-specific values in the very first middleware.
+  app.use('/*', (req, res, next) => {
+    setLatestRes(res);
+    res.locals.functionExecutionFinished = false;
+    next();
+  });
+
+  /**
+   * Retains a reference to the raw body buffer to allow access to the raw body
+   * for things like request signature validation.  This is used as the "verify"
+   * function in body-parser options.
+   * @param req Express request object.
+   * @param res Express response object.
+   * @param buf Buffer to be saved.
+   */
+  function rawBodySaver(
+    req: express.Request,
+    res: express.Response,
+    buf: Buffer
+  ) {
+    req.rawBody = buf;
+  }
+
+  // Set limit to a value larger than 32MB, which is maximum limit of higher
+  // level layers anyway.
+  const requestLimit = '1024mb';
+  const defaultBodySavingOptions = {
+    limit: requestLimit,
+    verify: rawBodySaver,
+  };
+  const cloudEventsBodySavingOptions = {
+    type: 'application/cloudevents+json',
+    limit: requestLimit,
+    verify: rawBodySaver,
+  };
+  const rawBodySavingOptions = {
+    limit: requestLimit,
+    verify: rawBodySaver,
+    type: '*/*',
+  };
+
+  // Use extended query string parsing for URL-encoded bodies.
+  const urlEncodedOptions = {
+    limit: requestLimit,
+    verify: rawBodySaver,
+    extended: true,
+  };
+
+  // Apply middleware
+  app.use(bodyParser.json(cloudEventsBodySavingOptions));
+  app.use(bodyParser.json(defaultBodySavingOptions));
+  app.use(bodyParser.text(defaultBodySavingOptions));
+  app.use(bodyParser.urlencoded(urlEncodedOptions));
+  // The parser will process ALL content types so MUST come last.
+  // Subsequent parsers will be skipped when one is matched.
+  app.use(bodyParser.raw(rawBodySavingOptions));
+  app.enable('trust proxy'); // To respect X-Forwarded-For header.
+
+  registerFunctionRoutes(app, userFunction, functionSignatureType);
+  return http.createServer(app);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,3 +15,9 @@
 // HTTP header field that is added to Worker response to signalize problems with
 // executing the client function.
 export const FUNCTION_STATUS_HEADER_FIELD = 'X-Google-Status';
+
+export enum SignatureType {
+  HTTP = 'http',
+  EVENT = 'event',
+  CLOUDEVENT = 'cloudevent',
+}

--- a/test/invoker.ts
+++ b/test/invoker.ts
@@ -15,7 +15,8 @@
 import * as assert from 'assert';
 import * as express from 'express';
 import * as functions from '../src/functions';
-import * as invoker from '../src/invoker';
+import {getServer} from '../src/server';
+import {SignatureType} from '../src/types';
 import * as supertest from 'supertest';
 
 describe('request to HTTP function', () => {
@@ -61,12 +62,12 @@ describe('request to HTTP function', () => {
   testData.forEach(test => {
     it(`should return transformed body: ${test.name}`, async () => {
       var callCount = 0;
-      const server = invoker.getServer(
+      const server = getServer(
         (req: express.Request, res: express.Response) => {
           ++callCount;
           res.send(req.body.text.toUpperCase());
         },
-        invoker.SignatureType.HTTP
+        SignatureType.HTTP
       );
       await supertest(server)
         .post(test.path)
@@ -136,12 +137,12 @@ describe('GCF event request to event function', () => {
     it(`should receive data and context from ${test.name}`, async () => {
       let receivedData: {} | null = null;
       let receivedContext: functions.CloudFunctionsContext | null = null;
-      const server = invoker.getServer(
+      const server = getServer(
         (data: {}, context: functions.Context) => {
           receivedData = data;
           receivedContext = context as functions.CloudFunctionsContext;
         },
-        invoker.SignatureType.EVENT
+        SignatureType.EVENT
       );
       await supertest(server)
         .post('/')
@@ -203,12 +204,12 @@ describe('CloudEvents request to event function', () => {
     it(`should receive data and context from ${test.name}`, async () => {
       let receivedData: {} | null = null;
       let receivedContext: functions.CloudEventsContext | null = null;
-      const server = invoker.getServer(
+      const server = getServer(
         (data: {}, context: functions.Context) => {
           receivedData = data;
           receivedContext = context as functions.CloudEventsContext;
         },
-        invoker.SignatureType.EVENT
+        SignatureType.EVENT
       );
       await supertest(server)
         .post('/')
@@ -265,11 +266,11 @@ describe('CloudEvents request to cloudevent function', () => {
   testData.forEach(test => {
     it(`should receive data and context from ${test.name}`, async () => {
       let receivedCloudEvent: functions.CloudEventsContext | null = null;
-      const server = invoker.getServer(
+      const server = getServer(
         (cloudevent: functions.CloudEventsContext) => {
           receivedCloudEvent = cloudevent as functions.CloudEventsContext;
         },
-        invoker.SignatureType.CLOUDEVENT
+        SignatureType.CLOUDEVENT
       );
       await supertest(server)
         .post('/')


### PR DESCRIPTION
Refactors the router/server/invoker.

The invoker file is pretty large, tries to slim down that file by creating a new `router.ts` file.

Does not change functionality.

---

Hoping to integrate the CE SDK next. We probably should add some more tests.