### PR TITLE
fix: Do not pass numeric arguments to res.send

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -44,7 +44,10 @@ export function sendCrashResponse({
   // execution sends the response between the check and 'send' call below.
   if (res && !res.headersSent) {
     res.set(FUNCTION_STATUS_HEADER_FIELD, 'crash');
-    res.send(err.message || err);
+    const message = err.message || err;
+    const sanitizedMessage =
+      typeof message === 'number' ? String(message) : message;
+    res.send(sanitizedMessage);
   }
   if (callback) {
     callback();

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -44,10 +44,7 @@ export function sendCrashResponse({
   // execution sends the response between the check and 'send' call below.
   if (res && !res.headersSent) {
     res.set(FUNCTION_STATUS_HEADER_FIELD, 'crash');
-    const message = err.message || err;
-    const sanitizedMessage =
-      typeof message === 'number' ? String(message) : message;
-    res.send(sanitizedMessage);
+    res.send((err.message || err) + '');
   }
   if (callback) {
     callback();


### PR DESCRIPTION
Fixes #239.

res.send when receiving a sole numeric argument will set thee statuc code to that number.

This breaks HTTP communication as some numbers are not valid HTTP response codes.

For example, in the original issue the code is being set to 2. Which probably comes from the UNKNOWN error response of an RPC call.

This makes that the function is reported as having a `connection error`.