### PR TITLE
fix: remove custom rawBody interface from request invoker

### DIFF
--- a/src/invoker.ts
+++ b/src/invoker.ts
@@ -35,17 +35,6 @@ import {
   CloudEventFunctionWithCallback,
 } from './functions';
 
-// We optionally annotate the express Request with a rawBody field.
-// Express leaves the Express namespace open to allow merging of new fields.
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace Express {
-    export interface Request {
-      rawBody?: Buffer;
-    }
-  }
-}
-
 /**
  * Response object for the most recent request.
  * Used for sending errors to the user.

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,44 +43,24 @@ export function getServer(
     next();
   });
 
-  /**
-   * Retains a reference to the raw body buffer to allow access to the raw body
-   * for things like request signature validation.  This is used as the "verify"
-   * function in body-parser options.
-   * @param req Express request object.
-   * @param res Express response object.
-   * @param buf Buffer to be saved.
-   */
-  function rawBodySaver(
-    req: express.Request,
-    res: express.Response,
-    buf: Buffer
-  ) {
-    req.rawBody = buf;
-  }
-
   // Set limit to a value larger than 32MB, which is maximum limit of higher
   // level layers anyway.
   const requestLimit = '1024mb';
   const defaultBodySavingOptions = {
     limit: requestLimit,
-    verify: rawBodySaver,
   };
   const cloudEventsBodySavingOptions = {
     type: 'application/cloudevents+json',
     limit: requestLimit,
-    verify: rawBodySaver,
   };
   const rawBodySavingOptions = {
     limit: requestLimit,
-    verify: rawBodySaver,
     type: '*/*',
   };
 
   // Use extended query string parsing for URL-encoded bodies.
   const urlEncodedOptions = {
     limit: requestLimit,
-    verify: rawBodySaver,
     extended: true,
   };
 


### PR DESCRIPTION
Removes the added `rawBody` field from requests.

This is used in the body-parser [`verify`](https://www.npmjs.com/package/body-parser#verify) callback hook (it doesn't actually verify the payload).

I'm not sure exactly the history around this field. The field, `req.rawBody` is there when testing in GCF, and it stores the JSON HTTP POST body in a byte array.

Example request:

```
 curl -XPOST https://us-central1-....cloudfunctions.net/function-26 -H "content-type: application/json" -d '{ "name": "fo" }'
```

Example response (that you need to parse):

```
JSON.parse("{\"type\":\"Buffer\",\"data\":[123,32,34,110,97,109,101,34,58,32,34,102,111,34,32,125]}")
```

Fixes https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/198

This would be a breaking change.