### PR TITLE
fix: smooth functions crash

### DIFF
--- a/src/invoker.ts
+++ b/src/invoker.ts
@@ -277,8 +277,9 @@ export class ErrorHandler {
           res: latestRes,
           silent: true,
           callback: () => {
+            // eslint-disable-next-line no-process-exit
             process.exit();
-          }
+          },
         });
       });
     });

--- a/src/invoker.ts
+++ b/src/invoker.ts
@@ -272,10 +272,13 @@ export class ErrorHandler {
 
     ['SIGINT', 'SIGTERM'].forEach(signal => {
       process.on(signal as NodeJS.Signals, () => {
-        console.log(`Received ${signal}`);
-        this.server.close(() => {
-          // eslint-disable-next-line no-process-exit
-          process.exit();
+        sendCrashResponse({
+          err: new Error(`Received ${signal}`),
+          res: latestRes,
+          silent: true,
+          callback: () => {
+            process.exit();
+          }
         });
       });
     });


### PR DESCRIPTION
Simplifies CTRL + C exit by immediately exiting process. Should make the local development exiting process better. Removes the "Received ^C" message. Tested locally.

Fixes: https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/260

More context is here too: https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/126#issuecomment-638220477

I believe the Node server was kept alive in some cases, even after a SIGINT, which makes the local dev process frustrating.

## Example FF cancel

```
npm start

> ffnodelocalerr@1.0.0 start /Users/timmerman/Documents/trash/ffnodelocalerr
> functions-framework --target=helloWorld

Serving function...
Function: helloWorld
Signature type: http
URL: http://localhost:8080/
^C%      
```

## Example test

```json
{
  "name": "ffnodelocalerr",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "start": "functions-framework --target=helloWorld",
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "ISC",
  "dependencies": {
    "@google-cloud/functions-framework": "file:/Users/timmerman/Documents/github/googlecloudplatform/functions-framework-nodejs"
  }
}
```

```js
/**
 * Send "Hello, World!"
 * @param req https://expressjs.com/en/api.html#req
 * @param res https://expressjs.com/en/api.html#res
 */
 exports.helloWorld = (req, res) => {
  res.send('Hello, World!');
};
```