### PR TITLE
ci: enable eslint for tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
 **/node_modules
 build/
-test/

--- a/test/conformance/function.js
+++ b/test/conformance/function.js
@@ -1,5 +1,5 @@
-const fs = require("fs");
-const fileName = "function_output.json";
+const fs = require('fs');
+const fileName = 'function_output.json';
 
 function writeHttp(req, res) {
   writeJson(req.body);
@@ -7,12 +7,12 @@ function writeHttp(req, res) {
 }
 
 function writeCloudEvent(cloudevent) {
-  cloudevent.datacontenttype = "application/json"
+  cloudevent.datacontenttype = 'application/json';
   writeJson(cloudevent);
 }
 
 function writeLegacyEvent(data, context) {
-  content = {
+  const content = {
     data: data,
     context: {
       eventId: context.eventId,
@@ -25,7 +25,7 @@ function writeLegacyEvent(data, context) {
 }
 
 function writeJson(content) {
-  json = JSON.stringify(content);
+  const json = JSON.stringify(content);
   fs.writeFileSync(fileName, json);
 }
 

--- a/test/data/with_main/foo.js
+++ b/test/data/with_main/foo.js
@@ -1,13 +1,14 @@
+/*eslint no-unused-vars: "off"*/
 /**
  * Test HTTP function to test function loading.
  *
  * @param {!Object} req request context.
  * @param {!Object} res response context.
  */
-function testFunction (req, res) {
-  return 'PASS'
-};
+function testFunction(req, res) {
+  return 'PASS';
+}
 
 module.exports = {
   testFunction,
-}
+};

--- a/test/data/without_main/function.js
+++ b/test/data/without_main/function.js
@@ -1,13 +1,14 @@
+/*eslint no-unused-vars: "off"*/
 /**
  * Test HTTP function to test function loading.
  *
  * @param {!Object} req request context.
  * @param {!Object} res response context.
  */
-function testFunction (req, res) {
-  return 'PASS'
-};
+function testFunction(req, res) {
+  return 'PASS';
+}
 
 module.exports = {
   testFunction,
-}
+};

--- a/test/invoker.ts
+++ b/test/invoker.ts
@@ -61,7 +61,7 @@ describe('request to HTTP function', () => {
 
   testData.forEach(test => {
     it(`should return transformed body: ${test.name}`, async () => {
-      var callCount = 0;
+      let callCount = 0;
       const server = getServer(
         (req: express.Request, res: express.Response) => {
           ++callCount;
@@ -71,7 +71,7 @@ describe('request to HTTP function', () => {
       );
       await supertest(server)
         .post(test.path)
-        .send({ text: 'hello' })
+        .send({text: 'hello'})
         .set('Content-Type', 'application/json')
         .expect(test.text)
         .expect(test.status);
@@ -96,7 +96,7 @@ describe('GCF event request to event function', () => {
           eventType: 'testEventType',
           resource: 'testResource',
         },
-        data: { some: 'payload' },
+        data: {some: 'payload'},
       },
       expectedResource: 'testResource',
     },
@@ -107,7 +107,7 @@ describe('GCF event request to event function', () => {
         timestamp: 'testTimestamp',
         eventType: 'testEventType',
         resource: 'testResource',
-        data: { some: 'payload' },
+        data: {some: 'payload'},
       },
       expectedResource: 'testResource',
     },
@@ -124,7 +124,7 @@ describe('GCF event request to event function', () => {
             type: 'testType',
           },
         },
-        data: { some: 'payload' },
+        data: {some: 'payload'},
       },
       expectedResource: {
         service: 'testService',
@@ -137,19 +137,16 @@ describe('GCF event request to event function', () => {
     it(`should receive data and context from ${test.name}`, async () => {
       let receivedData: {} | null = null;
       let receivedContext: functions.CloudFunctionsContext | null = null;
-      const server = getServer(
-        (data: {}, context: functions.Context) => {
-          receivedData = data;
-          receivedContext = context as functions.CloudFunctionsContext;
-        },
-        SignatureType.EVENT
-      );
+      const server = getServer((data: {}, context: functions.Context) => {
+        receivedData = data;
+        receivedContext = context as functions.CloudFunctionsContext;
+      }, SignatureType.EVENT);
       await supertest(server)
         .post('/')
         .send(test.body)
         .set('Content-Type', 'application/json')
         .expect(204);
-      assert.deepStrictEqual(receivedData, { some: 'payload' });
+      assert.deepStrictEqual(receivedData, {some: 'payload'});
       assert.notStrictEqual(receivedContext, null);
       assert.strictEqual(receivedContext!.eventId, 'testEventId');
       assert.strictEqual(receivedContext!.timestamp, 'testTimestamp');
@@ -175,14 +172,14 @@ const TEST_CLOUD_EVENT = {
 describe('CloudEvents request to event function', () => {
   interface TestData {
     name: string;
-    headers: { [key: string]: string };
+    headers: {[key: string]: string};
     body: {};
   }
 
   const testData: TestData[] = [
     {
       name: 'CloudEvents v1.0 structured content mode',
-      headers: { 'Content-Type': 'application/cloudevents+json' },
+      headers: {'Content-Type': 'application/cloudevents+json'},
       body: TEST_CLOUD_EVENT,
     },
     {
@@ -204,13 +201,10 @@ describe('CloudEvents request to event function', () => {
     it(`should receive data and context from ${test.name}`, async () => {
       let receivedData: {} | null = null;
       let receivedContext: functions.CloudEventsContext | null = null;
-      const server = getServer(
-        (data: {}, context: functions.Context) => {
-          receivedData = data;
-          receivedContext = context as functions.CloudEventsContext;
-        },
-        SignatureType.EVENT
-      );
+      const server = getServer((data: {}, context: functions.Context) => {
+        receivedData = data;
+        receivedContext = context as functions.CloudEventsContext;
+      }, SignatureType.EVENT);
       await supertest(server)
         .post('/')
         .set(test.headers)
@@ -238,14 +232,14 @@ describe('CloudEvents request to event function', () => {
 describe('CloudEvents request to cloudevent function', () => {
   interface TestData {
     name: string;
-    headers: { [key: string]: string };
+    headers: {[key: string]: string};
     body: {};
   }
 
   const testData: TestData[] = [
     {
       name: 'CloudEvents v1.0 structured content mode',
-      headers: { 'Content-Type': 'application/cloudevents+json' },
+      headers: {'Content-Type': 'application/cloudevents+json'},
       body: TEST_CLOUD_EVENT,
     },
     {
@@ -266,12 +260,9 @@ describe('CloudEvents request to cloudevent function', () => {
   testData.forEach(test => {
     it(`should receive data and context from ${test.name}`, async () => {
       let receivedCloudEvent: functions.CloudEventsContext | null = null;
-      const server = getServer(
-        (cloudevent: functions.CloudEventsContext) => {
-          receivedCloudEvent = cloudevent as functions.CloudEventsContext;
-        },
-        SignatureType.CLOUDEVENT
-      );
+      const server = getServer((cloudevent: functions.CloudEventsContext) => {
+        receivedCloudEvent = cloudevent as functions.CloudEventsContext;
+      }, SignatureType.CLOUDEVENT);
       await supertest(server)
         .post('/')
         .set(test.headers)

--- a/test/pubsub_middleware.ts
+++ b/test/pubsub_middleware.ts
@@ -14,7 +14,10 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import {Response, Request} from 'express';
-import {legacyPubSubEventMiddleware, MarshalledPubSubBody} from '../src/pubsub_middleware';
+import {
+  legacyPubSubEventMiddleware,
+  MarshalledPubSubBody,
+} from '../src/pubsub_middleware';
 
 const PUB_SUB_TOPIC = 'projects/FOO/topics/BAR_TOPIC';
 const RAW_PUBSUB_BODY = {
@@ -23,9 +26,9 @@ const RAW_PUBSUB_BODY = {
     data: 'eyJmb28iOiJiYXIifQ==',
     messageId: '1',
     attributes: {
-      test: '123'
-    }
-  }
+      test: '123',
+    },
+  },
 };
 
 const marshalledPubSubBody = (topic: string | null): MarshalledPubSubBody => ({
@@ -33,8 +36,8 @@ const marshalledPubSubBody = (topic: string | null): MarshalledPubSubBody => ({
     '@type': 'type.googleapis.com/google.pubsub.v1.PubsubMessage',
     data: 'eyJmb28iOiJiYXIifQ==',
     attributes: {
-      test: '123'
-    }
+      test: '123',
+    },
   },
   context: {
     eventId: '1',
@@ -42,10 +45,10 @@ const marshalledPubSubBody = (topic: string | null): MarshalledPubSubBody => ({
     resource: {
       name: topic,
       service: 'pubsub.googleapis.com',
-      type: 'type.googleapis.com/google.pubsub.v1.PubsubMessage'
+      type: 'type.googleapis.com/google.pubsub.v1.PubsubMessage',
     },
     timestamp: new Date().toISOString(),
-  }
+  },
 });
 
 describe('legacyPubSubEventMiddleware', () => {
@@ -69,19 +72,19 @@ describe('legacyPubSubEventMiddleware', () => {
       name: 'raw pub/sub request',
       path: `/${PUB_SUB_TOPIC}?pubsub_trigger=true`,
       body: RAW_PUBSUB_BODY,
-      expectedBody: () => marshalledPubSubBody(PUB_SUB_TOPIC)
+      expectedBody: () => marshalledPubSubBody(PUB_SUB_TOPIC),
     },
     {
       name: 'raw pub/sub request without topic in URL path',
       path: '/myfunction',
       body: RAW_PUBSUB_BODY,
-      expectedBody: () => marshalledPubSubBody(null)
+      expectedBody: () => marshalledPubSubBody(null),
     },
     {
       name: 'non-pub/sub request',
       path: `/${PUB_SUB_TOPIC}?pubsub_trigger=true`,
-      body: {foo: "bar"},
-      expectedBody: () => ({foo: "bar"})
+      body: {foo: 'bar'},
+      expectedBody: () => ({foo: 'bar'}),
     },
   ];
 
@@ -90,7 +93,7 @@ describe('legacyPubSubEventMiddleware', () => {
       const clock = sinon.useFakeTimers();
       const next = sinon.spy();
       const request = {
-        path: test.path, 
+        path: test.path,
         body: test.body,
       };
       legacyPubSubEventMiddleware(request as Request, {} as Response, next);


### PR DESCRIPTION
- Enables linting for tests (they were ignored before for some reason)
- Note: Almost all of the changes are generated from `npm run fix`