### PR TITLE
refactor!: use a union type for SignatureType

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -39,7 +39,7 @@ export function registerFunctionRoutes(
   userFunction: HandlerFunction,
   functionSignatureType: SignatureType
 ) {
-  if (functionSignatureType === SignatureType.HTTP) {
+  if (functionSignatureType === 'http') {
     app.use('/favicon.ico|/robots.txt', (req, res) => {
       // Neither crawlers nor browsers attempting to pull the icon find the body
       // contents particularly useful, so we send nothing in the response body.
@@ -57,7 +57,7 @@ export function registerFunctionRoutes(
       const handler = makeHttpHandler(userFunction as HttpFunction);
       handler(req, res, next);
     });
-  } else if (functionSignatureType === SignatureType.EVENT) {
+  } else if (functionSignatureType === 'event') {
     app.post('/*', (req, res, next) => {
       const wrappedUserFunction = wrapEventFunction(
         userFunction as EventFunction | EventFunctionWithCallback

--- a/src/server.ts
+++ b/src/server.ts
@@ -101,8 +101,8 @@ export function getServer(
   app.disable('x-powered-by');
 
   if (
-    functionSignatureType === SignatureType.EVENT ||
-    functionSignatureType === SignatureType.CLOUDEVENT
+    functionSignatureType === 'event' ||
+    functionSignatureType === 'cloudevent'
   ) {
     // If a Pub/Sub subscription is configured to invoke a user's function directly, the request body
     // needs to be marshalled into the structure that wrapEventFunction expects. This unblocks local
@@ -110,10 +110,10 @@ export function getServer(
     app.use(legacyPubSubEventMiddleware);
   }
 
-  if (functionSignatureType === SignatureType.EVENT) {
+  if (functionSignatureType === 'event') {
     app.use(cloudeventToBackgroundEventMiddleware);
   }
-  if (functionSignatureType === SignatureType.CLOUDEVENT) {
+  if (functionSignatureType === 'cloudevent') {
     app.use(backgroundEventToCloudEventMiddleware);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,8 +16,22 @@
 // executing the client function.
 export const FUNCTION_STATUS_HEADER_FIELD = 'X-Google-Status';
 
-export enum SignatureType {
-  HTTP = 'http',
-  EVENT = 'event',
-  CLOUDEVENT = 'cloudevent',
-}
+/**
+ * List of function signature types that are supported by the framework.
+ */
+export const SignatureType = ['http', 'event', 'cloudevent'] as const;
+
+/**
+ * Union type of all valid function SignatureType values.
+ */
+export type SignatureType = typeof SignatureType[number];
+
+/**
+ * Type guard to test if a provided value is valid SignatureType
+ * @param x the value to test
+ * @returns true if the provided value is a valid SignatureType
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isValidSignatureType = (x: any): x is SignatureType => {
+  return SignatureType.includes(x);
+};

--- a/test/integration/cloudevent.ts
+++ b/test/integration/cloudevent.ts
@@ -16,7 +16,6 @@ import * as assert from 'assert';
 import * as functions from '../../src/functions';
 import * as sinon from 'sinon';
 import {getServer} from '../../src/server';
-import {SignatureType} from '../../src/types';
 import * as supertest from 'supertest';
 
 const TEST_CLOUD_EVENT = {
@@ -224,7 +223,7 @@ describe('CloudEvent Function', () => {
       let receivedCloudEvent: functions.CloudEventsContext | null = null;
       const server = getServer((cloudevent: functions.CloudEventsContext) => {
         receivedCloudEvent = cloudevent as functions.CloudEventsContext;
-      }, SignatureType.CLOUDEVENT);
+      }, 'cloudevent');
       await supertest(server)
         .post('/')
         .set(test.headers)

--- a/test/integration/http.ts
+++ b/test/integration/http.ts
@@ -15,7 +15,6 @@
 import * as assert from 'assert';
 import * as express from 'express';
 import {getServer} from '../../src/server';
-import {SignatureType} from '../../src/types';
 import * as supertest from 'supertest';
 
 describe('HTTP Function', () => {
@@ -73,7 +72,7 @@ describe('HTTP Function', () => {
             query: req.query.param,
           });
         },
-        SignatureType.HTTP
+        'http'
       );
       const st = supertest(server);
       await (test.httpVerb === 'GET'

--- a/test/integration/legacy_event.ts
+++ b/test/integration/legacy_event.ts
@@ -15,7 +15,6 @@
 import * as assert from 'assert';
 import * as functions from '../../src/functions';
 import {getServer} from '../../src/server';
-import {SignatureType} from '../../src/types';
 import * as supertest from 'supertest';
 
 const TEST_CLOUD_EVENT = {
@@ -175,7 +174,7 @@ describe('Event Function', () => {
       const server = getServer((data: {}, context: functions.Context) => {
         receivedData = data;
         receivedContext = context as functions.CloudFunctionsContext;
-      }, SignatureType.EVENT);
+      }, 'event');
       const requestHeaders = {
         'Content-Type': 'application/json',
         ...test.headers,


### PR DESCRIPTION
This commit refactors the SignatureType enum into an array of strings declared [as const](https://github.com/Microsoft/TypeScript/pull/29510). This allows the `SignatureType` type to be expressed as a union type, which works a bit better when parsing a user provided string.

This is some simple refactoring in preparation for declarative function signatures.

BREAKING CHANGE: exported SignatureType type is converted from an enum to a union type