### PR TITLE
feat: enable traceparent header for cloudevents

### DIFF
--- a/src/function_wrappers.ts
+++ b/src/function_wrappers.ts
@@ -66,6 +66,11 @@ const parseCloudEventRequest = (req: Request): CloudEventsContext => {
     cloudevent = getBinaryCloudEventContext(req);
     cloudevent.data = req.body;
   }
+  // Populate the traceparent header.
+  // @see https://github.com/cloudevents/spec/blob/master/extensions/distributed-tracing.md
+  if (req.header('traceparent')) {
+    cloudevent.traceparent = req.header('traceparent');
+  }
   return cloudevent;
 };
 

--- a/test/integration/cloudevent.ts
+++ b/test/integration/cloudevent.ts
@@ -53,6 +53,17 @@ describe('CloudEvent Function', () => {
       expectedCloudEvent: TEST_CLOUD_EVENT,
     },
     {
+      name: 'CloudEvents v1.0 structured content request',
+      headers: {
+        traceparent: '00-65088630f09e0a5359677a7429456db7-97f23477fb2bf5ec-01',
+      },
+      body: TEST_CLOUD_EVENT,
+      expectedCloudEvent: {
+        ...TEST_CLOUD_EVENT,
+        traceparent: '00-65088630f09e0a5359677a7429456db7-97f23477fb2bf5ec-01',
+      },
+    },
+    {
       name: 'CloudEvents v1.0 binary content request',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
Fixes: https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/197

`traceparent` is the more modern header that includes information that `X-Cloud-Trace-Context` references.