### PR TITLE
ci: update conformance to 1.2.0

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,8 +1,6 @@
 name: Node.js Conformance CI
 on: 
   push:
-    branches:
-    - master
   pull_request:
 jobs:
   build:


### PR DESCRIPTION
No changes to conformance tests.

It's a little weird that we don't need changes. Perhaps is it due to GH actions not respecting minor semvers?

Fixes https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/317