### PR TITLE
feat: Add Google CloudEvent Types

### DIFF
--- a/experimental/generate_cloudevents/src/utils.ts
+++ b/experimental/generate_cloudevents/src/utils.ts
@@ -25,12 +25,22 @@ export const RELATIVE_SRC_DIR = '../../src/cloudevent_types';
  * Add a JSDoc comment to an AST node
  * @param node the AST node to add a comment to
  * @param comment the text content of the comment
+ * @param isPublic whether or not to add an "@public" annotation
  * @returns the AST node with attached comment
  */
-export const addComment = <T extends t.Node>(node: T, comment?: string): T => {
+export const addComment = <T extends t.Node>(
+  node: T,
+  comment?: string,
+  isPublic = false
+): T => {
   if (comment) {
     const lines = comment.split('\n').map(l => ' * ' + l.trim());
     lines.unshift('*');
+
+    if (isPublic) {
+      lines.push(' * ');
+      lines.push(' * @public');
+    }
 
     t.addComment(node, 'leading', lines.join('\n') + '\n ');
   }
@@ -91,6 +101,12 @@ export const getCloudEventTypeName = (dataTypeName: string): string => {
  * @returns the updated AST node
  */
 export const addCopyright = (file: t.File): t.File => {
+  t.addComment(
+    file,
+    'leading',
+    ' eslint-disable @typescript-eslint/no-explicit-any',
+    false
+  );
   [
     ' Copyright 2021 Google LLC',
     '',

--- a/src/cloudevent_types/CloudEvent.ts
+++ b/src/cloudevent_types/CloudEvent.ts
@@ -1,0 +1,54 @@
+/**
+ * The CloudEvents v1.0 context object for the event.
+ * {@link https://github.com/cloudevents/spec/blob/master/spec.md#context-attributes}
+ * @public
+ */
+export interface CloudEvent {
+  /**
+   * Type of occurrence which has happened.
+   */
+  type?: string;
+  /**
+   * The version of the CloudEvents specification which the event uses.
+   */
+  specversion?: string;
+  /**
+   * The event producer.
+   */
+  source?: string;
+  /**
+   * ID of the event.
+   */
+  id?: string;
+  /**
+   * Timestamp of when the event happened.
+   */
+  time?: string;
+  /**
+   * Describes the subject of the event in the context of the event producer.
+   */
+  subject?: string;
+  /**
+   * A link to the schema that the event data adheres to.
+   */
+  dataschema?: string;
+  /**
+   * Content type of the event data.
+   */
+  datacontenttype?: string;
+  /**
+   * The event data.
+   */
+  data?:
+    | Record<string, unknown | string | number | boolean>
+    | string
+    | number
+    | boolean
+    | null
+    | unknown;
+  /**
+   * The traceparent string, containing a trace version, trace ID, span ID, and trace options.
+   * @see https://github.com/cloudevents/spec/blob/master/extensions/distributed-tracing.md
+   */
+  traceparent?: string;
+}

--- a/src/cloudevent_types/GoogleCloudEvent.ts
+++ b/src/cloudevent_types/GoogleCloudEvent.ts
@@ -1,0 +1,167 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable @typescript-eslint/no-explicit-any*/
+import {LogEntryData} from './cloud/audit/v1/LogEntryData';
+import {BuildEventData} from './cloud/cloudbuild/v1/BuildEventData';
+import {DocumentEventData} from './cloud/firestore/v1/DocumentEventData';
+import {MessagePublishedData} from './cloud/pubsub/v1/MessagePublishedData';
+import {SchedulerJobData} from './cloud/scheduler/v1/SchedulerJobData';
+import {StorageObjectData} from './cloud/storage/v1/StorageObjectData';
+import {AnalyticsLogData} from './firebase/analytics/v1/AnalyticsLogData';
+import {AuthEventData} from './firebase/auth/v1/AuthEventData';
+import {ReferenceEventData} from './firebase/database/v1/ReferenceEventData';
+import {RemoteConfigEventData} from './firebase/remoteconfig/v1/RemoteConfigEventData';
+import {TestMatrixEventData} from './firebase/testlab/v1/TestMatrixEventData';
+import {CloudEvent} from './CloudEvent';
+
+/**
+ * The schema of CloudEvents emmitted by Cloud Audit Logs.
+ *
+ * @public
+ */
+export interface LogEntryCloudEvent extends CloudEvent {
+  type: 'google.cloud.audit.log.v1.written';
+  data: LogEntryData;
+}
+
+/**
+ * The schema of CloudEvents emmitted by Cloud Build.
+ *
+ * @public
+ */
+export interface BuildEventCloudEvent extends CloudEvent {
+  type: 'google.cloud.cloudbuild.build.v1.statusChanged';
+  data: BuildEventData;
+}
+
+/**
+ * The schema of CloudEvents emmitted by Cloud Firestore.
+ *
+ * @public
+ */
+export interface DocumentEventCloudEvent extends CloudEvent {
+  type:
+    | 'google.cloud.firestore.document.v1.created'
+    | 'google.cloud.firestore.document.v1.updated'
+    | 'google.cloud.firestore.document.v1.deleted'
+    | 'google.cloud.firestore.document.v1.written';
+  data: DocumentEventData;
+}
+
+/**
+ * The schema of CloudEvents emmitted by Cloud Pub/Sub.
+ *
+ * @public
+ */
+export interface MessagePublishedCloudEvent extends CloudEvent {
+  type: 'google.cloud.pubsub.topic.v1.messagePublished';
+  data: MessagePublishedData;
+}
+
+/**
+ * The schema of CloudEvents emmitted by Cloud Scheduler.
+ *
+ * @public
+ */
+export interface SchedulerJobCloudEvent extends CloudEvent {
+  type: 'google.cloud.scheduler.job.v1.executed';
+  data: SchedulerJobData;
+}
+
+/**
+ * The schema of CloudEvents emmitted by Cloud Storage.
+ *
+ * @public
+ */
+export interface StorageObjectCloudEvent extends CloudEvent {
+  type:
+    | 'google.cloud.storage.object.v1.finalized'
+    | 'google.cloud.storage.object.v1.archived'
+    | 'google.cloud.storage.object.v1.deleted'
+    | 'google.cloud.storage.object.v1.metadataUpdated';
+  data: StorageObjectData;
+}
+
+/**
+ * The schema of CloudEvents emmitted by Google Analytics for Firebase.
+ *
+ * @public
+ */
+export interface AnalyticsLogCloudEvent extends CloudEvent {
+  type: 'google.firebase.analytics.log.v1.written';
+  data: AnalyticsLogData;
+}
+
+/**
+ * The schema of CloudEvents emmitted by Firebase Authentication.
+ *
+ * @public
+ */
+export interface AuthEventCloudEvent extends CloudEvent {
+  type:
+    | 'google.firebase.auth.user.v1.created'
+    | 'google.firebase.auth.user.v1.deleted';
+  data: AuthEventData;
+}
+
+/**
+ * The schema of CloudEvents emmitted by Firebase Realtime Database.
+ *
+ * @public
+ */
+export interface ReferenceEventCloudEvent extends CloudEvent {
+  type:
+    | 'google.firebase.database.ref.v1.created'
+    | 'google.firebase.database.ref.v1.updated'
+    | 'google.firebase.database.ref.v1.deleted'
+    | 'google.firebase.database.ref.v1.written';
+  data: ReferenceEventData;
+}
+
+/**
+ * The schema of CloudEvents emmitted by Firebase Remote Config.
+ *
+ * @public
+ */
+export interface RemoteConfigEventCloudEvent extends CloudEvent {
+  type: 'google.firebase.remoteconfig.remoteConfig.v1.updated';
+  data: RemoteConfigEventData;
+}
+
+/**
+ * The schema of CloudEvents emmitted by Firebase Test Lab.
+ *
+ * @public
+ */
+export interface TestMatrixEventCloudEvent extends CloudEvent {
+  type: 'google.firebase.testlab.testMatrix.v1.completed';
+  data: TestMatrixEventData;
+}
+
+/**
+ * Union of all known CloudEvents emitted by Google Cloud services
+ */
+export type GoogleCloudEvent =
+  | LogEntryCloudEvent
+  | BuildEventCloudEvent
+  | DocumentEventCloudEvent
+  | MessagePublishedCloudEvent
+  | SchedulerJobCloudEvent
+  | StorageObjectCloudEvent
+  | AnalyticsLogCloudEvent
+  | AuthEventCloudEvent
+  | ReferenceEventCloudEvent
+  | RemoteConfigEventCloudEvent
+  | TestMatrixEventCloudEvent;

--- a/src/cloudevent_types/cloud/audit/v1/LogEntryData.ts
+++ b/src/cloudevent_types/cloud/audit/v1/LogEntryData.ts
@@ -1,0 +1,764 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable @typescript-eslint/no-explicit-any*/
+
+/**
+ * The data within all Cloud Audit Logs log entry events.
+ *
+ * @public
+ */
+export interface LogEntryData {
+  /**
+   * The resource name of the log to which this log entry belongs.
+   */
+  logName: string;
+
+  /**
+   * The monitored resource that produced this log entry.
+   *
+   * Example: a log entry that reports a database error would be associated with
+   * the monitored resource designating the particular database that reported
+   * the error.
+   */
+  resource: MonitoredResource;
+
+  /**
+   * The log entry payload, which is always an AuditLog for Cloud Audit Log
+   * events.
+   */
+  protoPayload: AuditLog;
+
+  /**
+   * A unique identifier for the log entry.
+   */
+  insertId: string;
+
+  /**
+   * A set of user-defined (key, value) data that provides additional
+   * information about the log entry.
+   */
+  labels: object;
+
+  /**
+   * Information about an operation associated with the log entry, if
+   * applicable.
+   */
+  operation: LogEntryOperation;
+
+  /**
+   * The time the event described by the log entry occurred.
+   */
+  timestamp: string;
+
+  /**
+   * The time the log entry was received by Logging.
+   */
+  receiveTimestamp: string;
+
+  /**
+   * The severity of the log entry.
+   */
+  severity: number;
+
+  /**
+   * Resource name of the trace associated with the log entry, if any. If it
+   * contains a relative resource name, the name is assumed to be relative to
+   * `//tracing.googleapis.com`. Example:
+   * `projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824`
+   */
+  trace: string;
+
+  /**
+   * The span ID within the trace associated with the log entry, if any.
+   *
+   * For Trace spans, this is the same format that the Trace API v2 uses: a
+   * 16-character hexadecimal encoding of an 8-byte array, such as
+   * `000000000000004a`.
+   */
+  spanId: string;
+}
+
+/**
+ * Note: this is a much-reduced version of the proto at
+ * https://github.com/googleapis/googleapis/blob/master/google/api/monitored_resource.proto
+ * to avoid other dependencies leaking into events.
+ *
+ * An object representing a resource that can be used for monitoring, logging,
+ * billing, or other purposes.
+ *
+ * @public
+ */
+export interface MonitoredResource {
+  /**
+   * Required. The monitored resource type. For example, the type of a
+   * Compute Engine VM instance is `gce_instance`.
+   */
+  type: string;
+
+  /**
+   * Values for all of the labels listed in the associated monitored
+   * resource descriptor. For example, Compute Engine VM instances use the
+   * labels `"project_id"`, `"instance_id"`, and `"zone"`.
+   */
+  labels: object;
+}
+
+/**
+ * Common audit log format for Google Cloud Platform API operations.
+ * Copied from
+ * https://github.com/googleapis/googleapis/blob/master/google/cloud/audit/audit_log.proto,
+ * but changing service_data from Any to Struct.
+ *
+ * @public
+ */
+export interface AuditLog {
+  /**
+   * The name of the API service performing the operation. For example,
+   * `"datastore.googleapis.com"`.
+   */
+  serviceName: string;
+
+  /**
+   * The name of the service method or operation.
+   * For API calls, this should be the name of the API method.
+   * For example,
+   *
+   * "google.datastore.v1.Datastore.RunQuery"
+   * "google.logging.v1.LoggingService.DeleteLog"
+   */
+  methodName: string;
+
+  /**
+   * The resource or collection that is the target of the operation.
+   * The name is a scheme-less URI, not including the API service name.
+   * For example:
+   *
+   * "shelves/SHELF_ID/books"
+   * "shelves/SHELF_ID/books/BOOK_ID"
+   */
+  resourceName: string;
+
+  /**
+   * The resource location information.
+   */
+  resourceLocation: ResourceLocation;
+
+  /**
+   * The resource's original state before mutation. Present only for
+   * operations which have successfully modified the targeted resource(s).
+   * In general, this field should contain all changed fields, except those
+   * that are already been included in `request`, `response`, `metadata` or
+   * `service_data` fields.
+   * When the JSON object represented here has a proto equivalent,
+   * the proto name will be indicated in the `@type` property.
+   */
+  resourceOriginalState: object;
+
+  /**
+   * The number of items returned from a List or Query API method,
+   * if applicable.
+   */
+  numResponseItems: number;
+
+  /**
+   * The status of the overall operation.
+   */
+  status: Status;
+
+  /**
+   * Authentication information.
+   */
+  authenticationInfo: AuthenticationInfo;
+
+  /**
+   * Authorization information. If there are multiple
+   * resources or permissions involved, then there is
+   * one AuthorizationInfo element for each {resource, permission} tuple.
+   */
+  authorizationInfo: AuthorizationInfo[];
+
+  /**
+   * Metadata about the operation.
+   */
+  requestMetadata: RequestMetadata;
+
+  /**
+   * The operation request. This may not include all request parameters,
+   * such as those that are too large, privacy-sensitive, or duplicated
+   * elsewhere in the log record.
+   * It should never include user-generated data, such as file contents.
+   * When the JSON object represented here has a proto equivalent, the proto
+   * name will be indicated in the `@type` property.
+   */
+  request: object;
+
+  /**
+   * The operation response. This may not include all response elements,
+   * such as those that are too large, privacy-sensitive, or duplicated
+   * elsewhere in the log record.
+   * It should never include user-generated data, such as file contents.
+   * When the JSON object represented here has a proto equivalent, the proto
+   * name will be indicated in the `@type` property.
+   */
+  response: object;
+
+  /**
+   * Other service-specific data about the request, response, and other
+   * information associated with the current audited event.
+   */
+  metadata: object;
+
+  /**
+   * Deprecated: Use `metadata` field instead.
+   * Other service-specific data about the request, response, and other
+   * activities.
+   * When the JSON object represented here has a proto equivalent, the proto
+   * name will be indicated in the `@type` property.
+   */
+  serviceData: object;
+}
+
+/**
+ * Authentication information for the operation.
+ *
+ * @public
+ */
+export interface AuthenticationInfo {
+  /**
+   * The email address of the authenticated user (or service account on behalf
+   * of third party principal) making the request. For privacy reasons, the
+   * principal email address is redacted for all read-only operations that fail
+   * with a "permission denied" error.
+   */
+  principalEmail: string;
+
+  /**
+   * The authority selector specified by the requestor, if any.
+   * It is not guaranteed that the principal was allowed to use this authority.
+   */
+  authoritySelector: string;
+
+  /**
+   * The third party identification (if any) of the authenticated user making
+   * the request.
+   * When the JSON object represented here has a proto equivalent, the proto
+   * name will be indicated in the `@type` property.
+   */
+  thirdPartyPrincipal: object;
+
+  /**
+   * The name of the service account key used to create or exchange
+   * credentials for authenticating the service account making the request.
+   * This is a scheme-less URI full resource name. For example:
+   *
+   * "//iam.googleapis.com/projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{key}"
+   */
+  serviceAccountKeyName: string;
+
+  /**
+   * Identity delegation history of an authenticated service account that makes
+   * the request. It contains information on the real authorities that try to
+   * access GCP resources by delegating on a service account. When multiple
+   * authorities present, they are guaranteed to be sorted based on the original
+   * ordering of the identity delegation events.
+   */
+  serviceAccountDelegationInfo: ServiceAccountDelegationInfo[];
+
+  /**
+   * String representation of identity of requesting party.
+   * Populated for both first and third party identities.
+   */
+  principalSubject: string;
+}
+
+/**
+ * Authorization information for the operation.
+ *
+ * @public
+ */
+export interface AuthorizationInfo {
+  /**
+   * The resource being accessed, as a REST-style string. For example:
+   *
+   * bigquery.googleapis.com/projects/PROJECTID/datasets/DATASETID
+   */
+  resource: string;
+
+  /**
+   * The required IAM permission.
+   */
+  permission: string;
+
+  /**
+   * Whether or not authorization for `resource` and `permission`
+   * was granted.
+   */
+  granted: boolean;
+
+  /**
+   * Resource attributes used in IAM condition evaluation. This field contains
+   * resource attributes like resource type and resource name.
+   *
+   * To get the whole view of the attributes used in IAM
+   * condition evaluation, the user must also look into
+   * `AuditLogData.request_metadata.request_attributes`.
+   */
+  resourceAttributes: Resource;
+}
+
+/**
+ * Additional information about a potentially long-running operation with which
+ * a log entry is associated.
+ *
+ * @public
+ */
+export interface LogEntryOperation {
+  /**
+   * An arbitrary operation identifier. Log entries with the same
+   * identifier are assumed to be part of the same operation.
+   */
+  id: string;
+
+  /**
+   * An arbitrary producer identifier. The combination of `id` and
+   * `producer` must be globally unique. Examples for `producer`:
+   * `"MyDivision.MyBigCompany.com"`, `"github.com/MyProject/MyApplication"`.
+   */
+  producer: string;
+
+  /**
+   * True if this is the first log entry in the operation.
+   */
+  first: boolean;
+
+  /**
+   * True if this is the last log entry in the operation.
+   */
+  last: boolean;
+}
+
+/**
+ * Metadata about the request.
+ *
+ * @public
+ */
+export interface RequestMetadata {
+  /**
+   * The IP address of the caller.
+   * For caller from internet, this will be public IPv4 or IPv6 address.
+   * For caller from a Compute Engine VM with external IP address, this
+   * will be the VM's external IP address. For caller from a Compute
+   * Engine VM without external IP address, if the VM is in the same
+   * organization (or project) as the accessed resource, `caller_ip` will
+   * be the VM's internal IPv4 address, otherwise the `caller_ip` will be
+   * redacted to "gce-internal-ip".
+   * See https://cloud.google.com/compute/docs/vpc/ for more information.
+   */
+  callerIp: string;
+
+  /**
+   * The user agent of the caller.
+   * This information is not authenticated and should be treated accordingly.
+   * For example:
+   *
+   * +   `google-api-python-client/1.4.0`:
+   * The request was made by the Google API client for Python.
+   * +   `Cloud SDK Command Line Tool apitools-client/1.0 gcloud/0.9.62`:
+   * The request was made by the Google Cloud SDK CLI (gcloud).
+   * +   `AppEngine-Google; (+http://code.google.com/appengine; appid:
+   * s~my-project`:
+   * The request was made from the `my-project` App Engine app.
+   */
+  callerSuppliedUserAgent: string;
+
+  /**
+   * The network of the caller.
+   * Set only if the network host project is part of the same GCP organization
+   * (or project) as the accessed resource.
+   * See https://cloud.google.com/compute/docs/vpc/ for more information.
+   * This is a scheme-less URI full resource name. For example:
+   *
+   * "//compute.googleapis.com/projects/PROJECT_ID/global/networks/NETWORK_ID"
+   */
+  callerNetwork: string;
+
+  /**
+   * Request attributes used in IAM condition evaluation. This field contains
+   * request attributes like request time and access levels associated with
+   * the request.
+   *
+   *
+   * To get the whole view of the attributes used in IAM
+   * condition evaluation, the user must also look into
+   * `AuditLog.authentication_info.resource_attributes`.
+   */
+  requestAttributes: Request;
+
+  /**
+   * The destination of a network activity, such as accepting a TCP connection.
+   * In a multi hop network activity, the destination represents the receiver of
+   * the last hop. Only two fields are used in this message, Peer.port and
+   * Peer.ip. These fields are optionally populated by those services utilizing
+   * the IAM condition feature.
+   */
+  destinationAttributes: Peer;
+}
+
+/**
+ * Location information about a resource.
+ *
+ * @public
+ */
+export interface ResourceLocation {
+  /**
+   * The locations of a resource after the execution of the operation.
+   * Requests to create or delete a location based resource must populate
+   * the 'current_locations' field and not the 'original_locations' field.
+   * For example:
+   *
+   * "europe-west1-a"
+   * "us-east1"
+   * "nam3"
+   */
+  currentLocations: string[];
+
+  /**
+   * The locations of a resource prior to the execution of the operation.
+   * Requests that mutate the resource's location must populate both the
+   * 'original_locations' as well as the 'current_locations' fields.
+   * For example:
+   *
+   * "europe-west1-a"
+   * "us-east1"
+   * "nam3"
+   */
+  originalLocations: string[];
+}
+
+/**
+ * Identity delegation history of an authenticated service account.
+ *
+ * @public
+ */
+export interface ServiceAccountDelegationInfo {
+  /**
+   * First party (Google) identity as the real authority.
+   */
+  firstPartyPrincipal: FirstPartyPrincipal;
+
+  /**
+   * Third party identity as the real authority.
+   */
+  thirdPartyPrincipal: ThirdPartyPrincipal;
+}
+
+/**
+ * First party identity principal.
+ *
+ * @public
+ */
+export interface FirstPartyPrincipal {
+  /**
+   * The email address of a Google account.
+   */
+  principalEmail: string;
+
+  /**
+   * Metadata about the service that uses the service account.
+   */
+  serviceMetadata: object;
+}
+
+/**
+ * Third party identity principal.
+ *
+ * @public
+ */
+export interface ThirdPartyPrincipal {
+  /**
+   * Metadata about third party identity.
+   */
+  thirdPartyClaims: object;
+}
+
+/**
+ * The `Status` type defines a logical error model that is suitable for
+ * different programming environments, including REST APIs and RPC APIs. It is
+ * used by [gRPC](https://github.com/grpc). Each `Status` message contains
+ * three pieces of data: error code, error message, and error details.
+ *
+ * You can find out more about this error model and how to work with it in the
+ * [API Design Guide](https://cloud.google.com/apis/design/errors).
+ *
+ * @public
+ */
+export interface Status {
+  /**
+   * The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+   */
+  code: number;
+
+  /**
+   * A developer-facing error message, which should be in English. Any
+   * user-facing error message should be localized and sent in the
+   * [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+   */
+  message: string;
+
+  /**
+   * A list of messages that carry the error details.  There is a common set of
+   * message types for APIs to use.
+   */
+  details: object[];
+}
+
+/**
+ * This message defines request authentication attributes. Terminology is
+ * based on the JSON Web Token (JWT) standard, but the terms also
+ * correlate to concepts in other standards.
+ *
+ * @public
+ */
+export interface Auth {
+  /**
+   * The authenticated principal. Reflects the issuer (`iss`) and subject
+   * (`sub`) claims within a JWT. The issuer and subject should be `/`
+   * delimited, with `/` percent-encoded within the subject fragment. For
+   * Google accounts, the principal format is:
+   * "https://accounts.google.com/{id}"
+   */
+  principal: string;
+
+  /**
+   * The intended audience(s) for this authentication information. Reflects
+   * the audience (`aud`) claim within a JWT. The audience
+   * value(s) depends on the `issuer`, but typically include one or more of
+   * the following pieces of information:
+   *
+   * *  The services intended to receive the credential such as
+   * ["pubsub.googleapis.com", "storage.googleapis.com"]
+   * *  A set of service-based scopes. For example,
+   * ["https://www.googleapis.com/auth/cloud-platform"]
+   * *  The client id of an app, such as the Firebase project id for JWTs
+   * from Firebase Auth.
+   *
+   * Consult the documentation for the credential issuer to determine the
+   * information provided.
+   */
+  audiences: string[];
+
+  /**
+   * The authorized presenter of the credential. Reflects the optional
+   * Authorized Presenter (`azp`) claim within a JWT or the
+   * OAuth client id. For example, a Google Cloud Platform client id looks
+   * as follows: "123456789012.apps.googleusercontent.com".
+   */
+  presenter: string;
+
+  /**
+   * Structured claims presented with the credential. JWTs include
+   * `{key: value}` pairs for standard and private claims. The following
+   * is a subset of the standard required and optional claims that would
+   * typically be presented for a Google-based JWT:
+   *
+   * {'iss': 'accounts.google.com',
+   * 'sub': '113289723416554971153',
+   * 'aud': ['123456789012', 'pubsub.googleapis.com'],
+   * 'azp': '123456789012.apps.googleusercontent.com',
+   * 'email': 'jsmith@example.com',
+   * 'iat': 1353601026,
+   * 'exp': 1353604926}
+   *
+   * SAML assertions are similarly specified, but with an identity provider
+   * dependent structure.
+   */
+  claims: object;
+
+  /**
+   * A list of access level resource names that allow resources to be
+   * accessed by authenticated requester. It is part of Secure GCP processing
+   * for the incoming request. An access level string has the format:
+   * "//{api_service_name}/accessPolicies/{policy_id}/accessLevels/{short_name}"
+   *
+   * Example:
+   * "//accesscontextmanager.googleapis.com/accessPolicies/MY_POLICY_ID/accessLevels/MY_LEVEL"
+   */
+  accessLevels: string[];
+}
+
+/**
+ * This message defines attributes for a node that handles a network request.
+ * The node can be either a service or an application that sends, forwards,
+ * or receives the request. Service peers should fill in
+ * `principal` and `labels` as appropriate.
+ *
+ * @public
+ */
+export interface Peer {
+  /**
+   * The IP address of the peer.
+   */
+  ip: string;
+
+  /**
+   * The network port of the peer.
+   */
+  port: number;
+
+  /**
+   * The labels associated with the peer.
+   */
+  labels: object;
+
+  /**
+   * The identity of this peer. Similar to `Request.auth.principal`, but
+   * relative to the peer instead of the request. For example, the
+   * idenity associated with a load balancer that forwared the request.
+   */
+  principal: string;
+
+  /**
+   * The CLDR country/region code associated with the above IP address.
+   * If the IP address is private, the `region_code` should reflect the
+   * physical location where this peer is running.
+   */
+  regionCode: string;
+}
+
+/**
+ * This message defines attributes for an HTTP request. If the actual
+ * request is not an HTTP request, the runtime system should try to map
+ * the actual request to an equivalent HTTP request.
+ *
+ * @public
+ */
+export interface Request {
+  /**
+   * The unique ID for a request, which can be propagated to downstream
+   * systems. The ID should have low probability of collision
+   * within a single day for a specific service.
+   */
+  id: string;
+
+  /**
+   * The HTTP request method, such as `GET`, `POST`.
+   */
+  method: string;
+
+  /**
+   * The HTTP request headers. If multiple headers share the same key, they
+   * must be merged according to the HTTP spec. All header keys must be
+   * lowercased, because HTTP header keys are case-insensitive.
+   */
+  headers: object;
+
+  /**
+   * The HTTP URL path.
+   */
+  path: string;
+
+  /**
+   * The HTTP request `Host` header value.
+   */
+  host: string;
+
+  /**
+   * The HTTP URL scheme, such as `http` and `https`.
+   */
+  scheme: string;
+
+  /**
+   * The HTTP URL query in the format of `name1=value1&name2=value2`, as it
+   * appears in the first line of the HTTP request. No decoding is performed.
+   */
+  query: string;
+
+  /**
+   * The timestamp when the `destination` service receives the first byte of
+   * the request.
+   */
+  time: string;
+
+  /**
+   * The HTTP request size in bytes. If unknown, it must be -1.
+   */
+  size: number;
+
+  /**
+   * The network protocol used with the request, such as "http/1.1",
+   * "spdy/3", "h2", "h2c", "webrtc", "tcp", "udp", "quic". See
+   * https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
+   * for details.
+   */
+  protocol: string;
+
+  /**
+   * A special parameter for request reason. It is used by security systems
+   * to associate auditing information with a request.
+   */
+  reason: string;
+
+  /**
+   * The request authentication. May be absent for unauthenticated requests.
+   * Derived from the HTTP request `Authorization` header or equivalent.
+   */
+  auth: Auth;
+}
+
+/**
+ * This message defines core attributes for a resource. A resource is an
+ * addressable (named) entity provided by the destination service. For
+ * example, a file stored on a network storage service.
+ *
+ * @public
+ */
+export interface Resource {
+  /**
+   * The name of the service that this resource belongs to, such as
+   * `pubsub.googleapis.com`. The service may be different from the DNS
+   * hostname that actually serves the request.
+   */
+  service: string;
+
+  /**
+   * The stable identifier (name) of a resource on the `service`. A resource
+   * can be logically identified as "//{resource.service}/{resource.name}".
+   * The differences between a resource name and a URI are:
+   *
+   * *   Resource name is a logical identifier, independent of network
+   * protocol and API version. For example,
+   * `//pubsub.googleapis.com/projects/123/topics/news-feed`.
+   * *   URI often includes protocol and version information, so it can
+   * be used directly by applications. For example,
+   * `https://pubsub.googleapis.com/v1/projects/123/topics/news-feed`.
+   *
+   * See https://cloud.google.com/apis/design/resource_names for details.
+   */
+  name: string;
+
+  /**
+   * The type of the resource. The syntax is platform-specific because
+   * different platforms define their resources differently.
+   *
+   * For Google APIs, the type format must be "{service}/{kind}".
+   */
+  type: string;
+
+  /**
+   * The labels or tags on the resource, such as AWS resource tags and
+   * Kubernetes resource labels.
+   */
+  labels: object;
+}

--- a/src/cloudevent_types/cloud/cloudbuild/v1/BuildEventData.ts
+++ b/src/cloudevent_types/cloud/cloudbuild/v1/BuildEventData.ts
@@ -1,0 +1,733 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable @typescript-eslint/no-explicit-any*/
+
+/**
+ * Build event data for Google Cloud Platform API operations.
+ *
+ * @public
+ */
+export interface BuildEventData {
+  /**
+   * Unique identifier of the build.
+   */
+  id: string;
+
+  /**
+   * ID of the project.
+   */
+  projectId: string;
+
+  /**
+   * Status of the build.
+   */
+  status: number;
+
+  /**
+   * Customer-readable message about the current status.
+   */
+  statusDetail: string;
+
+  /**
+   * The location of the source files to build.
+   */
+  source: Source;
+
+  /**
+   * The operations to be performed on the workspace.
+   */
+  steps: BuildStep[];
+
+  /**
+   * Results of the build.
+   */
+  results: Results;
+
+  /**
+   * Time at which the request to create the build was received.
+   */
+  createTime: string;
+
+  /**
+   * Time at which execution of the build was started.
+   */
+  startTime: string;
+
+  /**
+   * Time at which execution of the build was finished.
+   *
+   * The difference between finish_time and start_time is the duration of the
+   * build's execution.
+   */
+  finishTime: string;
+
+  /**
+   * Amount of time that this build should be allowed to run, to second
+   * granularity. If this amount of time elapses, work on the build will cease
+   * and the build status will be `TIMEOUT`.
+   */
+  timeout: string;
+
+  /**
+   * A list of images to be pushed upon the successful completion of all build
+   * steps.
+   *
+   * The images are pushed using the builder service account's credentials.
+   *
+   * The digests of the pushed images will be stored in the `Build` resource's
+   * results field.
+   *
+   * If any of the images fail to be pushed, the build status is marked
+   * `FAILURE`.
+   */
+  images: string[];
+
+  /**
+   * TTL in queue for this build. If provided and the build is enqueued longer
+   * than this value, the build will expire and the build status will be
+   * `EXPIRED`.
+   *
+   * The TTL starts ticking from create_time.
+   */
+  queueTtl: string;
+
+  /**
+   * Artifacts produced by the build that should be uploaded upon
+   * successful completion of all build steps.
+   */
+  artifacts: Artifacts;
+
+  /**
+   * Google Cloud Storage bucket where logs should be written (see
+   * [Bucket Name
+   * Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).
+   * Logs file names will be of the format `${logs_bucket}/log-${build_id}.txt`.
+   */
+  logsBucket: string;
+
+  /**
+   * A permanent fixed identifier for source.
+   */
+  sourceProvenance: SourceProvenance;
+
+  /**
+   * The ID of the `BuildTrigger` that triggered this build, if it
+   * was triggered automatically.
+   */
+  buildTriggerId: string;
+
+  /**
+   * Special options for this build.
+   */
+  options: BuildOptions;
+
+  /**
+   * URL to logs for this build in Google Cloud Console.
+   */
+  logUrl: string;
+
+  /**
+   * Substitutions data for `Build` resource.
+   */
+  substitutions: object;
+
+  /**
+   * Tags for annotation of a `Build`. These are not docker tags.
+   */
+  tags: string[];
+
+  /**
+   * Secrets to decrypt using Cloud Key Management Service.
+   */
+  secrets: Secret[];
+
+  /**
+   * Stores timing information for phases of the build. Valid keys
+   * are:
+   *
+   * * BUILD: time to execute all build steps
+   * * PUSH: time to push all specified images.
+   * * FETCHSOURCE: time to fetch source.
+   *
+   * If the build does not specify source or images,
+   * these keys will not be included.
+   */
+  timing: object;
+}
+
+/**
+ * Artifacts produced by a build that should be uploaded upon
+ * successful completion of all build steps.
+ *
+ * @public
+ */
+export interface Artifacts {
+  /**
+   * A list of images to be pushed upon the successful completion of all build
+   * steps.
+   *
+   * The images will be pushed using the builder service account's credentials.
+   *
+   * The digests of the pushed images will be stored in the Build resource's
+   * results field.
+   *
+   * If any of the images fail to be pushed, the build is marked FAILURE.
+   */
+  images: string[];
+
+  /**
+   * A list of objects to be uploaded to Cloud Storage upon successful
+   * completion of all build steps.
+   *
+   * Files in the workspace matching specified paths globs will be uploaded to
+   * the specified Cloud Storage location using the builder service account's
+   * credentials.
+   *
+   * The location and generation of the uploaded objects will be stored in the
+   * Build resource's results field.
+   *
+   * If any objects fail to be pushed, the build is marked FAILURE.
+   */
+  objects: ArtifactObjects;
+}
+
+/**
+ * Files in the workspace to upload to Cloud Storage upon successful
+ * completion of all build steps.
+ *
+ * @public
+ */
+export interface ArtifactObjects {
+  /**
+   * Cloud Storage bucket and optional object path, in the form
+   * "gs://bucket/path/to/somewhere/". (see [Bucket Name
+   * Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).
+   *
+   * Files in the workspace matching any path pattern will be uploaded to
+   * Cloud Storage with this location as a prefix.
+   */
+  location: string;
+
+  /**
+   * Path globs used to match files in the build's workspace.
+   */
+  paths: string[];
+
+  /**
+   * Stores timing information for pushing all artifact objects.
+   */
+  timing: TimeSpan;
+}
+
+/**
+ * Optional arguments to enable specific features of builds.
+ *
+ * @public
+ */
+export interface BuildOptions {
+  /**
+   * Requested hash for SourceProvenance.
+   */
+  sourceProvenanceHash: number[];
+
+  /**
+   * Requested verifiability options.
+   */
+  requestedVerifyOption: number;
+
+  /**
+   * Compute Engine machine type on which to run the build.
+   */
+  machineType: number;
+
+  /**
+   * Requested disk size for the VM that runs the build. Note that this is *NOT*
+   * "disk free"; some of the space will be used by the operating system and
+   * build utilities. Also note that this is the minimum disk size that will be
+   * allocated for the build -- the build may run with a larger disk than
+   * requested. At present, the maximum disk size is 1000GB; builds that request
+   * more than the maximum are rejected with an error.
+   */
+  diskSizeGb: number;
+
+  /**
+   * Option to specify behavior when there is an error in the substitution
+   * checks.
+   */
+  substitutionOption: number;
+
+  /**
+   * Option to define build log streaming behavior to Google Cloud
+   * Storage.
+   */
+  logStreamingOption: number;
+
+  /**
+   * Option to specify a `WorkerPool` for the build.
+   * Format: projects/{project}/locations/{location}/workerPools/{workerPool}
+   */
+  workerPool: string;
+
+  /**
+   * Option to specify the logging mode, which determines where the logs are
+   * stored.
+   */
+  logging: number;
+
+  /**
+   * A list of global environment variable definitions that will exist for all
+   * build steps in this build. If a variable is defined in both globally and in
+   * a build step, the variable will use the build step value.
+   *
+   * The elements are of the form "KEY=VALUE" for the environment variable "KEY"
+   * being given the value "VALUE".
+   */
+  env: string[];
+
+  /**
+   * A list of global environment variables, which are encrypted using a Cloud
+   * Key Management Service crypto key. These values must be specified in the
+   * build's `Secret`. These variables will be available to all build steps
+   * in this build.
+   */
+  secretEnv: string[];
+
+  /**
+   * Global list of volumes to mount for ALL build steps
+   *
+   * Each volume is created as an empty volume prior to starting the build
+   * process. Upon completion of the build, volumes and their contents are
+   * discarded. Global volume names and paths cannot conflict with the volumes
+   * defined a build step.
+   *
+   * Using a global volume in a build with only one step is not valid as
+   * it is indicative of a build request with an incorrect configuration.
+   */
+  volumes: Volume[];
+}
+
+/**
+ * A step in the build pipeline.
+ *
+ * @public
+ */
+export interface BuildStep {
+  /**
+   * The name of the container image that will run this particular
+   * build step.
+   *
+   * If the image is available in the host's Docker daemon's cache, it
+   * will be run directly. If not, the host will attempt to pull the image
+   * first, using the builder service account's credentials if necessary.
+   *
+   * The Docker daemon's cache will already have the latest versions of all of
+   * the officially supported build steps
+   * ([https://github.com/GoogleCloudPlatform/cloud-builders](https://github.com/GoogleCloudPlatform/cloud-builders)).
+   * The Docker daemon will also have cached many of the layers for some popular
+   * images, like "ubuntu", "debian", but they will be refreshed at the time you
+   * attempt to use them.
+   *
+   * If you built an image in a previous build step, it will be stored in the
+   * host's Docker daemon's cache and is available to use as the name for a
+   * later build step.
+   */
+  name: string;
+
+  /**
+   * A list of environment variable definitions to be used when running a step.
+   *
+   * The elements are of the form "KEY=VALUE" for the environment variable "KEY"
+   * being given the value "VALUE".
+   */
+  env: string[];
+
+  /**
+   * A list of arguments that will be presented to the step when it is started.
+   *
+   * If the image used to run the step's container has an entrypoint, the `args`
+   * are used as arguments to that entrypoint. If the image does not define
+   * an entrypoint, the first element in args is used as the entrypoint,
+   * and the remainder will be used as arguments.
+   */
+  args: string[];
+
+  /**
+   * Working directory to use when running this step's container.
+   *
+   * If this value is a relative path, it is relative to the build's working
+   * directory. If this value is absolute, it may be outside the build's working
+   * directory, in which case the contents of the path may not be persisted
+   * across build step executions, unless a `volume` for that path is specified.
+   *
+   * If the build specifies a `RepoSource` with `dir` and a step with a `dir`,
+   * which specifies an absolute path, the `RepoSource` `dir` is ignored for
+   * the step's execution.
+   */
+  dir: string;
+
+  /**
+   * Unique identifier for this build step, used in `wait_for` to
+   * reference this build step as a dependency.
+   */
+  id: string;
+
+  /**
+   * The ID(s) of the step(s) that this build step depends on.
+   * This build step will not start until all the build steps in `wait_for`
+   * have completed successfully. If `wait_for` is empty, this build step will
+   * start when all previous build steps in the `Build.Steps` list have
+   * completed successfully.
+   */
+  waitFor: string[];
+
+  /**
+   * Entrypoint to be used instead of the build step image's default entrypoint.
+   * If unset, the image's default entrypoint is used.
+   */
+  entrypoint: string;
+
+  /**
+   * A list of environment variables which are encrypted using a Cloud Key
+   * Management Service crypto key. These values must be specified in the
+   * build's `Secret`.
+   */
+  secretEnv: string[];
+
+  /**
+   * List of volumes to mount into the build step.
+   *
+   * Each volume is created as an empty volume prior to execution of the
+   * build step. Upon completion of the build, volumes and their contents are
+   * discarded.
+   *
+   * Using a named volume in only one step is not valid as it is indicative
+   * of a build request with an incorrect configuration.
+   */
+  volumes: Volume[];
+
+  /**
+   * Stores timing information for executing this build step.
+   */
+  timing: TimeSpan;
+
+  /**
+   * Stores timing information for pulling this build step's
+   * builder image only.
+   */
+  pullTiming: TimeSpan;
+
+  /**
+   * Time limit for executing this build step. If not defined, the step has no
+   * time limit and will be allowed to continue to run until either it completes
+   * or the build itself times out.
+   */
+  timeout: string;
+
+  /**
+   * Status of the build step. At this time, build step status is
+   * only updated on build completion; step status is not updated in real-time
+   * as the build progresses.
+   */
+  status: number;
+}
+
+/**
+ * An image built by the pipeline.
+ *
+ * @public
+ */
+export interface BuiltImage {
+  /**
+   * Name used to push the container image to Google Container Registry, as
+   * presented to `docker push`.
+   */
+  name: string;
+
+  /**
+   * Docker Registry 2.0 digest.
+   */
+  digest: string;
+
+  /**
+   * Stores timing information for pushing the specified image.
+   */
+  pushTiming: TimeSpan;
+}
+
+/**
+ * Container message for hashes of byte content of files, used in
+ * SourceProvenance messages to verify integrity of source input to the build.
+ *
+ * @public
+ */
+export interface FileHashes {
+  /**
+   * Collection of file hashes.
+   */
+  fileHash: Hash[];
+}
+
+/**
+ * Container message for hash values.
+ *
+ * @public
+ */
+export interface Hash {
+  /**
+   * The type of hash that was performed.
+   */
+  type: number;
+
+  /**
+   * The hash value.
+   */
+  value: string;
+}
+
+/**
+ * Location of the source in a Google Cloud Source Repository.
+ *
+ * @public
+ */
+export interface RepoSource {
+  /**
+   * ID of the project that owns the Cloud Source Repository.
+   */
+  projectId: string;
+
+  /**
+   * Name of the Cloud Source Repository.
+   */
+  repoName: string;
+
+  /**
+   * Regex matching branches to build.
+   *
+   * The syntax of the regular expressions accepted is the syntax accepted by
+   * RE2 and described at https://github.com/google/re2/wiki/Syntax
+   */
+  branchName: string;
+
+  /**
+   * Regex matching tags to build.
+   *
+   * The syntax of the regular expressions accepted is the syntax accepted by
+   * RE2 and described at https://github.com/google/re2/wiki/Syntax
+   */
+  tagName: string;
+
+  /**
+   * Explicit commit SHA to build.
+   */
+  commitSha: string;
+
+  /**
+   * Directory, relative to the source root, in which to run the build.
+   *
+   * This must be a relative path. If a step's `dir` is specified and is an
+   * absolute path, this value is ignored for that step's execution.
+   */
+  dir: string;
+
+  /**
+   * Only trigger a build if the revision regex does NOT match the revision
+   * regex.
+   */
+  invertRegex: boolean;
+
+  /**
+   * Substitutions to use in a triggered build.
+   * Should only be used with RunBuildTrigger
+   */
+  substitutions: object;
+}
+
+/**
+ * Artifacts created by the build pipeline.
+ *
+ * @public
+ */
+export interface Results {
+  /**
+   * Container images that were built as a part of the build.
+   */
+  images: BuiltImage[];
+
+  /**
+   * List of build step digests, in the order corresponding to build step
+   * indices.
+   */
+  buildStepImages: string[];
+
+  /**
+   * Path to the artifact manifest. Only populated when artifacts are uploaded.
+   */
+  artifactManifest: string;
+
+  /**
+   * Number of artifacts uploaded. Only populated when artifacts are uploaded.
+   */
+  numArtifacts: number;
+
+  /**
+   * List of build step outputs, produced by builder images, in the order
+   * corresponding to build step indices.
+   *
+   * [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders)
+   * can produce this output by writing to `$BUILDER_OUTPUT/output`.
+   * Only the first 4KB of data is stored.
+   */
+  buildStepOutputs: string[];
+
+  /**
+   * Time to push all non-container artifacts.
+   */
+  artifactTiming: TimeSpan;
+}
+
+/**
+ * Pairs a set of secret environment variables containing encrypted
+ * values with the Cloud KMS key to use to decrypt the value.
+ *
+ * @public
+ */
+export interface Secret {
+  /**
+   * Cloud KMS key name to use to decrypt these envs.
+   */
+  kmsKeyName: string;
+
+  /**
+   * Map of environment variable name to its encrypted value.
+   *
+   * Secret environment variables must be unique across all of a build's
+   * secrets, and must be used by at least one build step. Values can be at most
+   * 64 KB in size. There can be at most 100 secret values across all of a
+   * build's secrets.
+   */
+  secretEnv: object;
+}
+export interface Source {
+  /**
+   * If provided, get the source from this location in Google Cloud Storage.
+   */
+  storageSource: StorageSource;
+
+  /**
+   * If provided, get the source from this location in a Cloud Source
+   * Repository.
+   */
+  repoSource: RepoSource;
+}
+
+/**
+ * Provenance of the source. Ways to find the original source, or verify that
+ * some source was used for this build.
+ *
+ * @public
+ */
+export interface SourceProvenance {
+  /**
+   * A copy of the build's `source.storage_source`, if exists, with any
+   * generations resolved.
+   */
+  resolvedStorageSource: StorageSource;
+
+  /**
+   * A copy of the build's `source.repo_source`, if exists, with any
+   * revisions resolved.
+   */
+  resolvedRepoSource: RepoSource;
+
+  /**
+   * Hash(es) of the build source, which can be used to verify that
+   * the original source integrity was maintained in the build. Note that
+   * `FileHashes` will only be populated if `BuildOptions` has requested a
+   * `SourceProvenanceHash`.
+   *
+   * The keys to this map are file paths used as build source and the values
+   * contain the hash values for those files.
+   *
+   * If the build source came in a single package such as a gzipped tarfile
+   * (`.tar.gz`), the `FileHash` will be for the single path to that file.
+   */
+  fileHashes: object;
+}
+
+/**
+ * Location of the source in an archive file in Google Cloud Storage.
+ *
+ * @public
+ */
+export interface StorageSource {
+  /**
+   * Google Cloud Storage bucket containing the source (see
+   * [Bucket Name
+   * Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).
+   */
+  bucket: string;
+
+  /**
+   * Google Cloud Storage object containing the source.
+   */
+  object: string;
+
+  /**
+   * Google Cloud Storage generation for the object. If the generation is
+   * omitted, the latest generation will be used.
+   */
+  generation: number;
+}
+
+/**
+ * Start and end times for a build execution phase.
+ *
+ * @public
+ */
+export interface TimeSpan {
+  /**
+   * Start of time span.
+   */
+  startTime: string;
+
+  /**
+   * End of time span.
+   */
+  endTime: string;
+}
+
+/**
+ * Volume describes a Docker container volume which is mounted into build steps
+ * in order to persist files across build step execution.
+ *
+ * @public
+ */
+export interface Volume {
+  /**
+   * Name of the volume to mount.
+   *
+   * Volume names must be unique per build step and must be valid names for
+   * Docker volumes. Each named volume must be used by at least two build steps.
+   */
+  name: string;
+
+  /**
+   * Path at which to mount the volume.
+   *
+   * Paths must be absolute and cannot conflict with other volume paths on the
+   * same build step or with certain reserved volume paths.
+   */
+  path: string;
+}

--- a/src/cloudevent_types/cloud/firestore/v1/DocumentEventData.ts
+++ b/src/cloudevent_types/cloud/firestore/v1/DocumentEventData.ts
@@ -1,0 +1,239 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable @typescript-eslint/no-explicit-any*/
+
+/**
+ * The data within all Firestore document events.
+ *
+ * @public
+ */
+export interface DocumentEventData {
+  /**
+   * A Document object containing a post-operation document snapshot.
+   * This is not populated for delete events.
+   */
+  value: Document;
+
+  /**
+   * A Document object containing a pre-operation document snapshot.
+   * This is only populated for update and delete events.
+   */
+  oldValue: Document;
+
+  /**
+   * A DocumentMask object that lists changed fields.
+   * This is only populated for update events.
+   */
+  updateMask: DocumentMask;
+}
+
+/**
+ * An array value.
+ *
+ * @public
+ */
+export interface ArrayValue {
+  /**
+   * Values in the array.
+   */
+  values: Value[];
+}
+
+/**
+ * A Firestore document.
+ *
+ * @public
+ */
+export interface Document {
+  /**
+   * The resource name of the document. For example:
+   * `projects/{project_id}/databases/{database_id}/documents/{document_path}`
+   */
+  name: string;
+
+  /**
+   * The document's fields.
+   *
+   * The map keys represent field names.
+   *
+   * A simple field name contains only characters `a` to `z`, `A` to `Z`,
+   * `0` to `9`, or `_`, and must not start with `0` to `9`. For example,
+   * `foo_bar_17`.
+   *
+   * Field names matching the regular expression `__.*__` are reserved. Reserved
+   * field names are forbidden except in certain documented contexts. The map
+   * keys, represented as UTF-8, must not exceed 1,500 bytes and cannot be
+   * empty.
+   *
+   * Field paths may be used in other contexts to refer to structured fields
+   * defined here. For `map_value`, the field path is represented by the simple
+   * or quoted field names of the containing fields, delimited by `.`. For
+   * example, the structured field
+   * `"foo" : { map_value: { "x&y" : { string_value: "hello" }}}` would be
+   * represented by the field path `foo.x&y`.
+   *
+   * Within a field path, a quoted field name starts and ends with `` ` `` and
+   * may contain any character. Some characters, including `` ` ``, must be
+   * escaped using a `\`. For example, `` `x&y` `` represents `x&y` and
+   * `` `bak\`tik` `` represents `` bak`tik ``.
+   */
+  fields: object;
+
+  /**
+   * The time at which the document was created.
+   *
+   * This value increases monotonically when a document is deleted then
+   * recreated. It can also be compared to values from other documents and
+   * the `read_time` of a query.
+   */
+  createTime: string;
+
+  /**
+   * The time at which the document was last changed.
+   *
+   * This value is initially set to the `create_time` then increases
+   * monotonically with each change to the document. It can also be
+   * compared to values from other documents and the `read_time` of a query.
+   */
+  updateTime: string;
+}
+
+/**
+ * A set of field paths on a document.
+ *
+ * @public
+ */
+export interface DocumentMask {
+  /**
+   * The list of field paths in the mask.
+   * See [Document.fields][google.cloud.firestore.v1.events.Document.fields]
+   * for a field path syntax reference.
+   */
+  fieldPaths: string[];
+}
+
+/**
+ * A map value.
+ *
+ * @public
+ */
+export interface MapValue {
+  /**
+   * The map's fields.
+   *
+   * The map keys represent field names. Field names matching the regular
+   * expression `__.*__` are reserved. Reserved field names are forbidden except
+   * in certain documented contexts. The map keys, represented as UTF-8, must
+   * not exceed 1,500 bytes and cannot be empty.
+   */
+  fields: object;
+}
+
+/**
+ * A message that can hold any of the supported value types.
+ *
+ * @public
+ */
+export interface Value {
+  /**
+   * A null value.
+   */
+  nullValue: number;
+
+  /**
+   * A boolean value.
+   */
+  booleanValue: boolean;
+
+  /**
+   * An integer value.
+   */
+  integerValue: number;
+
+  /**
+   * A double value.
+   */
+  doubleValue: number;
+
+  /**
+   * A timestamp value.
+   *
+   * Precise only to microseconds. When stored, any additional precision is
+   * rounded down.
+   */
+  timestampValue: string;
+
+  /**
+   * A string value.
+   *
+   * The string, represented as UTF-8, must not exceed 1 MiB - 89 bytes.
+   * Only the first 1,500 bytes of the UTF-8 representation are considered by
+   * queries.
+   */
+  stringValue: string;
+
+  /**
+   * A bytes value.
+   *
+   * Must not exceed 1 MiB - 89 bytes.
+   * Only the first 1,500 bytes are considered by queries.
+   */
+  bytesValue: string;
+
+  /**
+   * A reference to a document. For example:
+   * `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+   */
+  referenceValue: string;
+
+  /**
+   * A geo point value representing a point on the surface of Earth.
+   */
+  geoPointValue: LatLng;
+
+  /**
+   * An array value.
+   *
+   * Cannot directly contain another array value, though can contain an
+   * map which contains another array.
+   */
+  arrayValue: ArrayValue;
+
+  /**
+   * A map value.
+   */
+  mapValue: MapValue;
+}
+
+/**
+ * An object representing a latitude/longitude pair. This is expressed as a pair
+ * of doubles representing degrees latitude and degrees longitude. Unless
+ * specified otherwise, this must conform to the
+ * <a href="http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf">WGS84
+ * standard</a>. Values must be within normalized ranges.
+ *
+ * @public
+ */
+export interface LatLng {
+  /**
+   * The latitude in degrees. It must be in the range [-90.0, +90.0].
+   */
+  latitude: number;
+
+  /**
+   * The longitude in degrees. It must be in the range [-180.0, +180.0].
+   */
+  longitude: number;
+}

--- a/src/cloudevent_types/cloud/pubsub/v1/MessagePublishedData.ts
+++ b/src/cloudevent_types/cloud/pubsub/v1/MessagePublishedData.ts
@@ -1,0 +1,69 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable @typescript-eslint/no-explicit-any*/
+
+/**
+ * The event data when a message is published to a topic.
+ *
+ * @public
+ */
+export interface MessagePublishedData {
+  /**
+   * The message that was published.
+   */
+  message: PubsubMessage;
+
+  /**
+   * The resource name of the subscription for which this event was
+   * generated. The format of the value is
+   * `projects/{project-id}/subscriptions/{subscription-id}`.
+   */
+  subscription: string;
+}
+
+/**
+ * A message published to a topic.
+ *
+ * @public
+ */
+export interface PubsubMessage {
+  /**
+   * The binary data in the message.
+   */
+  data: string;
+
+  /**
+   * Attributes for this message.
+   */
+  attributes: object;
+
+  /**
+   * ID of this message, assigned by the server when the message is published.
+   * Guaranteed to be unique within the topic.
+   */
+  messageId: string;
+
+  /**
+   * The time at which the message was published, populated by the server when
+   * it receives the `Publish` call.
+   */
+  publishTime: string;
+
+  /**
+   * If non-empty, identifies related messages for which publish order should be
+   * respected.
+   */
+  orderingKey: string;
+}

--- a/src/cloudevent_types/cloud/scheduler/v1/SchedulerJobData.ts
+++ b/src/cloudevent_types/cloud/scheduler/v1/SchedulerJobData.ts
@@ -1,0 +1,27 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable @typescript-eslint/no-explicit-any*/
+
+/**
+ * Scheduler job data.
+ *
+ * @public
+ */
+export interface SchedulerJobData {
+  /**
+   * The custom data the user specified when creating the scheduler source.
+   */
+  customData: string;
+}

--- a/src/cloudevent_types/cloud/storage/v1/StorageObjectData.ts
+++ b/src/cloudevent_types/cloud/storage/v1/StorageObjectData.ts
@@ -1,0 +1,212 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable @typescript-eslint/no-explicit-any*/
+
+/**
+ * An object within Google Cloud Storage.
+ *
+ * @public
+ */
+export interface StorageObjectData {
+  /**
+   * Content-Encoding of the object data, matching
+   * [https://tools.ietf.org/html/rfc7231#section-3.1.2.2][RFC 7231 §3.1.2.2]
+   */
+  contentEncoding: string;
+
+  /**
+   * Content-Disposition of the object data, matching
+   * [https://tools.ietf.org/html/rfc6266][RFC 6266].
+   */
+  contentDisposition: string;
+
+  /**
+   * Cache-Control directive for the object data, matching
+   * [https://tools.ietf.org/html/rfc7234#section-5.2"][RFC 7234 §5.2].
+   */
+  cacheControl: string;
+
+  /**
+   * Content-Language of the object data, matching
+   * [https://tools.ietf.org/html/rfc7231#section-3.1.3.2][RFC 7231 §3.1.3.2].
+   */
+  contentLanguage: string;
+
+  /**
+   * The version of the metadata for this object at this generation. Used for
+   * preconditions and for detecting changes in metadata. A metageneration
+   * number is only meaningful in the context of a particular generation of a
+   * particular object.
+   */
+  metageneration: number;
+
+  /**
+   * The deletion time of the object. Will be returned if and only if this
+   * version of the object has been deleted.
+   */
+  timeDeleted: string;
+
+  /**
+   * Content-Type of the object data, matching
+   * [https://tools.ietf.org/html/rfc7231#section-3.1.1.5][RFC 7231 §3.1.1.5].
+   * If an object is stored without a Content-Type, it is served as
+   * `application/octet-stream`.
+   */
+  contentType: string;
+
+  /**
+   * Content-Length of the object data in bytes, matching
+   * [https://tools.ietf.org/html/rfc7230#section-3.3.2][RFC 7230 §3.3.2].
+   */
+  size: number;
+
+  /**
+   * The creation time of the object.
+   * Attempting to set this field will result in an error.
+   */
+  timeCreated: string;
+
+  /**
+   * CRC32c checksum. For more information about using the CRC32c
+   * checksum, see
+   * [https://cloud.google.com/storage/docs/hashes-etags#_JSONAPI][Hashes and
+   * ETags: Best Practices].
+   */
+  crc32c: string;
+
+  /**
+   * Number of underlying components that make up this object. Components are
+   * accumulated by compose operations.
+   * Attempting to set this field will result in an error.
+   */
+  componentCount: number;
+
+  /**
+   * MD5 hash of the data; encoded using base64 as per
+   * [https://tools.ietf.org/html/rfc4648#section-4][RFC 4648 §4]. For more
+   * information about using the MD5 hash, see
+   * [https://cloud.google.com/storage/docs/hashes-etags#_JSONAPI][Hashes and
+   * ETags: Best Practices].
+   */
+  md5Hash: string;
+
+  /**
+   * HTTP 1.1 Entity tag for the object. See
+   * [https://tools.ietf.org/html/rfc7232#section-2.3][RFC 7232 §2.3].
+   */
+  etag: string;
+
+  /**
+   * The modification time of the object metadata.
+   */
+  updated: string;
+
+  /**
+   * Storage class of the object.
+   */
+  storageClass: string;
+
+  /**
+   * Cloud KMS Key used to encrypt this object, if the object is encrypted by
+   * such a key.
+   */
+  kmsKeyName: string;
+
+  /**
+   * The time at which the object's storage class was last changed.
+   */
+  timeStorageClassUpdated: string;
+
+  /**
+   * Whether an object is under temporary hold.
+   */
+  temporaryHold: boolean;
+
+  /**
+   * A server-determined value that specifies the earliest time that the
+   * object's retention period expires.
+   */
+  retentionExpirationTime: string;
+
+  /**
+   * User-provided metadata, in key/value pairs.
+   */
+  metadata: object;
+
+  /**
+   * Whether an object is under event-based hold.
+   */
+  eventBasedHold: boolean;
+
+  /**
+   * The name of the object.
+   */
+  name: string;
+
+  /**
+   * The ID of the object, including the bucket name, object name, and
+   * generation number.
+   */
+  id: string;
+
+  /**
+   * The name of the bucket containing this object.
+   */
+  bucket: string;
+
+  /**
+   * The content generation of this object. Used for object versioning.
+   * Attempting to set this field will result in an error.
+   */
+  generation: number;
+
+  /**
+   * Metadata of customer-supplied encryption key, if the object is encrypted by
+   * such a key.
+   */
+  customerEncryption: CustomerEncryption;
+
+  /**
+   * Media download link.
+   */
+  mediaLink: string;
+
+  /**
+   * The link to this object.
+   */
+  selfLink: string;
+
+  /**
+   * The kind of item this is. For objects, this is always "storage#object".
+   */
+  kind: string;
+}
+
+/**
+ * Describes the customer-specified mechanism used to store the data at rest.
+ *
+ * @public
+ */
+export interface CustomerEncryption {
+  /**
+   * The encryption algorithm.
+   */
+  encryptionAlgorithm: string;
+
+  /**
+   * SHA256 hash value of the encryption key.
+   */
+  keySha256: string;
+}

--- a/src/cloudevent_types/firebase/analytics/v1/AnalyticsLogData.ts
+++ b/src/cloudevent_types/firebase/analytics/v1/AnalyticsLogData.ts
@@ -1,0 +1,360 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable @typescript-eslint/no-explicit-any*/
+
+/**
+ * The data within Firebase Analytics log events.
+ *
+ * @public
+ */
+export interface AnalyticsLogData {
+  /**
+   * User related dimensions.
+   */
+  userDim: UserDimensions;
+
+  /**
+   * A repeated record of event related dimensions.
+   */
+  eventDim: EventDimensions[];
+}
+
+/**
+ * Value for Event Params and UserProperty can be of type string or int or
+ * float or double.
+ *
+ * @public
+ */
+export interface AnalyticsValue {
+  stringValue: string;
+  intValue: number;
+  floatValue: number;
+  doubleValue: number;
+}
+
+/**
+ * Message which contains App Information.
+ *
+ * @public
+ */
+export interface AppInfo {
+  /**
+   * The app's version name
+   * Examples: "1.0", "4.3.1.1.213361", "2.3 (1824253)", "v1.8b22p6"
+   */
+  appVersion: string;
+
+  /**
+   * Unique id for this instance of the app.
+   * Example: "71683BF9FA3B4B0D9535A1F05188BAF3"
+   */
+  appInstanceId: string;
+
+  /**
+   * The identifier of the store that installed the app.
+   * Eg. "com.sec.android.app.samsungapps", "com.amazon.venezia",
+   * "com.nokia.nstore"
+   */
+  appStore: string;
+
+  /**
+   * The app platform.
+   * Eg "ANDROID", "IOS".
+   */
+  appPlatform: string;
+
+  /**
+   * Unique application identifier within an app store.
+   */
+  appId: string;
+}
+
+/**
+ * Message containing device informations.
+ *
+ * @public
+ */
+export interface DeviceInfo {
+  /**
+   * Device category.
+   * Eg. tablet or mobile.
+   */
+  deviceCategory: string;
+
+  /**
+   * Device brand name.
+   * Eg. Samsung, HTC, etc.
+   */
+  mobileBrandName: string;
+
+  /**
+   * Device model name.
+   * Eg. GT-I9192
+   */
+  mobileModelName: string;
+
+  /**
+   * Device marketing name.
+   * Eg. Galaxy S4 Mini
+   */
+  mobileMarketingName: string;
+
+  /**
+   * Device model.
+   * Eg. GT-I9192
+   */
+  deviceModel: string;
+
+  /**
+   * Device OS version when data capture ended.
+   * Eg. 4.4.2
+   */
+  platformVersion: string;
+
+  /**
+   * Vendor specific device identifier. This is IDFV on iOS. Not used for
+   * Android.
+   * Example: "599F9C00-92DC-4B5C-9464-7971F01F8370"
+   */
+  deviceId: string;
+
+  /**
+   * The type of the resettable_device_id is always IDFA on iOS and AdId
+   * on Android.
+   * Example: "71683BF9-FA3B-4B0D-9535-A1F05188BAF3"
+   */
+  resettableDeviceId: string;
+
+  /**
+   * The user language.
+   * Eg. "en-us", "en-za", "zh-tw", "jp"
+   */
+  userDefaultLanguage: string;
+
+  /**
+   * The timezone of the device when data was uploaded as seconds skew from UTC.
+   */
+  deviceTimeZoneOffsetSeconds: number;
+
+  /**
+   * The device's Limit Ad Tracking setting.
+   * When true, we cannot use device_id for remarketing, demographics or
+   * influencing ads serving behaviour. However, we can use device_id for
+   * conversion tracking and campaign attribution.
+   */
+  limitedAdTracking: boolean;
+}
+
+/**
+ * Message containing information pertaining to the event.
+ *
+ * @public
+ */
+export interface EventDimensions {
+  /**
+   * The date on which this event was logged.
+   * (YYYYMMDD format in the registered timezone of your app.)
+   */
+  date: string;
+
+  /**
+   * The name of this event.
+   */
+  name: string;
+
+  /**
+   * A repeated record of the parameters associated with this event.
+   */
+  params: object;
+
+  /**
+   * UTC client time when the event happened.
+   */
+  timestampMicros: number;
+
+  /**
+   * UTC client time when the previous event happened.
+   */
+  previousTimestampMicros: number;
+
+  /**
+   * Value param in USD.
+   */
+  valueInUsd: number;
+}
+
+/**
+ * Message containing information regarding the bundle in which these
+ * events were uploaded.
+ *
+ * @public
+ */
+export interface ExportBundleInfo {
+  /**
+   * Monotonically increasing index for each bundle set by SDK.
+   */
+  bundleSequenceId: number;
+
+  /**
+   * Timestamp offset between collection time and upload time.
+   */
+  serverTimestampOffsetMicros: number;
+}
+
+/**
+ * User's geographic informaiton.
+ *
+ * @public
+ */
+export interface GeoInfo {
+  /**
+   * The geographic continent.
+   * Eg. Americas
+   */
+  continent: string;
+
+  /**
+   * The geographic country.
+   * Eg. Brazil
+   */
+  country: string;
+
+  /**
+   * The geographic region.
+   * Eg. State of Sao Paulo
+   */
+  region: string;
+
+  /**
+   * The geographic city.
+   * Eg. Sao Paulo
+   */
+  city: string;
+}
+
+/**
+ * Lifetime Value information about this user.
+ *
+ * @public
+ */
+export interface LtvInfo {
+  /**
+   * The Lifetime Value revenue of this user.
+   */
+  revenue: number;
+
+  /**
+   * The currency corresponding to the revenue.
+   */
+  currency: string;
+}
+
+/**
+ * Mesage containing marketing campaign information which acquired the user.
+ *
+ * @public
+ */
+export interface TrafficSource {
+  /**
+   * The name of the campaign which acquired the user.
+   */
+  userAcquiredCampaign: string;
+
+  /**
+   * The name of the network which acquired the user.
+   */
+  userAcquiredSource: string;
+
+  /**
+   * The name of the medium which acquired the user.
+   */
+  userAcquiredMedium: string;
+}
+
+/**
+ * Message containing information about the user associated with the event.
+ *
+ * @public
+ */
+export interface UserDimensions {
+  /**
+   * The user ID set via the setUserId API.
+   */
+  userId: string;
+
+  /**
+   * The time (in microseconds) at which the user first opened the app.
+   */
+  firstOpenTimestampMicros: number;
+
+  /**
+   * A repeated record of user properties set with the setUserProperty API.
+   * https://firebase.google.com/docs/analytics/android/properties
+   */
+  userProperties: object;
+
+  /**
+   * Device information.
+   */
+  deviceInfo: DeviceInfo;
+
+  /**
+   * User's geographic information.
+   */
+  geoInfo: GeoInfo;
+
+  /**
+   * App information.
+   */
+  appInfo: AppInfo;
+
+  /**
+   * Information about marketing campaign which acquired the user.
+   */
+  trafficSource: TrafficSource;
+
+  /**
+   * Information regarding the bundle in which these events were uploaded.
+   */
+  bundleInfo: ExportBundleInfo;
+
+  /**
+   * Lifetime Value information about this user.
+   */
+  ltvInfo: LtvInfo;
+}
+
+/**
+ * Predefined (eg: LTV) or custom properties (eg: birthday) stored on client
+ * side and associated with subsequent HitBundles.
+ *
+ * @public
+ */
+export interface UserPropertyValue {
+  /**
+   * Last set value of user property.
+   */
+  value: AnalyticsValue;
+
+  /**
+   * UTC client time when user property was last set.
+   */
+  setTimestampUsec: number;
+
+  /**
+   * Index for user property (one-based).
+   */
+  index: number;
+}

--- a/src/cloudevent_types/firebase/auth/v1/AuthEventData.ts
+++ b/src/cloudevent_types/firebase/auth/v1/AuthEventData.ts
@@ -1,0 +1,122 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable @typescript-eslint/no-explicit-any*/
+
+/**
+ * The data within all Firebase Auth events.
+ *
+ * @public
+ */
+export interface AuthEventData {
+  /**
+   * The user identifier in the Firebase app.
+   */
+  uid: string;
+
+  /**
+   * The user's primary email, if set.
+   */
+  email: string;
+
+  /**
+   * Whether or not the user's primary email is verified.
+   */
+  emailVerified: boolean;
+
+  /**
+   * The user's display name.
+   */
+  displayName: string;
+
+  /**
+   * The user's photo URL.
+   */
+  photoURL: string;
+
+  /**
+   * Whether the user is disabled.
+   */
+  disabled: boolean;
+
+  /**
+   * Additional metadata about the user.
+   */
+  metadata: UserMetadata;
+
+  /**
+   * User's info at the providers
+   */
+  providerData: UserInfo[];
+
+  /**
+   * The user's phone number.
+   */
+  phoneNumber: string;
+
+  /**
+   * User's custom claims, typically used to define user roles and propagated
+   * to an authenticated user's ID token.
+   */
+  customClaims: object;
+}
+
+/**
+ * User's info at the identity provider
+ *
+ * @public
+ */
+export interface UserInfo {
+  /**
+   * The user identifier for the linked provider.
+   */
+  uid: string;
+
+  /**
+   * The email for the linked provider.
+   */
+  email: string;
+
+  /**
+   * The display name for the linked provider.
+   */
+  displayName: string;
+
+  /**
+   * The photo URL for the linked provider.
+   */
+  photoURL: string;
+
+  /**
+   * The linked provider ID (e.g. "google.com" for the Google provider).
+   */
+  providerId: string;
+}
+
+/**
+ * Additional metadata about the user.
+ *
+ * @public
+ */
+export interface UserMetadata {
+  /**
+   * The date the user was created.
+   */
+  createTime: string;
+
+  /**
+   * The date the user last signed in.
+   */
+  lastSignInTime: string;
+}

--- a/src/cloudevent_types/firebase/database/v1/ReferenceEventData.ts
+++ b/src/cloudevent_types/firebase/database/v1/ReferenceEventData.ts
@@ -1,0 +1,42 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable @typescript-eslint/no-explicit-any*/
+
+/**
+ * The data within all Firebase Real Time Database reference events.
+ *
+ * @public
+ */
+export interface ReferenceEventData {
+  /**
+   * `Value` represents a dynamically typed value which can be either
+   * null, a number, a string, a boolean, a recursive struct value, or a
+   * list of values. A producer of value is expected to set one of that
+   * variants, absence of any variant indicates an error.
+   *
+   * The JSON representation for `Value` is JSON value.
+   */
+  data: any[] | boolean | number | object | string;
+
+  /**
+   * `Value` represents a dynamically typed value which can be either
+   * null, a number, a string, a boolean, a recursive struct value, or a
+   * list of values. A producer of value is expected to set one of that
+   * variants, absence of any variant indicates an error.
+   *
+   * The JSON representation for `Value` is JSON value.
+   */
+  delta: any[] | boolean | number | object | string;
+}

--- a/src/cloudevent_types/firebase/remoteconfig/v1/RemoteConfigEventData.ts
+++ b/src/cloudevent_types/firebase/remoteconfig/v1/RemoteConfigEventData.ts
@@ -1,0 +1,82 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable @typescript-eslint/no-explicit-any*/
+
+/**
+ * The data within all Firebase Remote Config events.
+ *
+ * @public
+ */
+export interface RemoteConfigEventData {
+  /**
+   * The version number of the version's corresponding Remote Config template.
+   */
+  versionNumber: number;
+
+  /**
+   * When the Remote Config template was written to the Remote Config server.
+   */
+  updateTime: string;
+
+  /**
+   * Aggregation of all metadata fields about the account that performed the
+   * update.
+   */
+  updateUser: RemoteConfigUser;
+
+  /**
+   * The user-provided description of the corresponding Remote Config template.
+   */
+  description: string;
+
+  /**
+   * Where the update action originated.
+   */
+  updateOrigin: number;
+
+  /**
+   * What type of update was made.
+   */
+  updateType: number;
+
+  /**
+   * Only present if this version is the result of a rollback, and will be the
+   * version number of the Remote Config template that was rolled-back to.
+   */
+  rollbackSource: number;
+}
+
+/**
+ * All the fields associated with the person/service account
+ * that wrote a Remote Config template.
+ *
+ * @public
+ */
+export interface RemoteConfigUser {
+  /**
+   * Display name.
+   */
+  name: string;
+
+  /**
+   * Email address.
+   */
+  email: string;
+
+  /**
+   * Image URL.
+   */
+  imageUrl: string;
+}

--- a/src/cloudevent_types/firebase/testlab/v1/TestMatrixEventData.ts
+++ b/src/cloudevent_types/firebase/testlab/v1/TestMatrixEventData.ts
@@ -1,0 +1,105 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable @typescript-eslint/no-explicit-any*/
+
+/**
+ * The data within all Firebase test matrix events.
+ *
+ * @public
+ */
+export interface TestMatrixEventData {
+  /**
+   * Time the test matrix was created.
+   */
+  createTime: string;
+
+  /**
+   * State of the test matrix.
+   */
+  state: number;
+
+  /**
+   * Code that describes why the test matrix is considered invalid. Only set for
+   * matrices in the INVALID state.
+   */
+  invalidMatrixDetails: string;
+
+  /**
+   * Outcome summary of the test matrix.
+   */
+  outcomeSummary: number;
+
+  /**
+   * Locations where test results are stored.
+   */
+  resultStorage: ResultStorage;
+
+  /**
+   * Information provided by the client that created the test matrix.
+   */
+  clientInfo: ClientInfo;
+}
+
+/**
+ * Information about the client which invoked the test.
+ *
+ * @public
+ */
+export interface ClientInfo {
+  /**
+   * Client name, such as "gcloud".
+   */
+  client: string;
+
+  /**
+   * Map of detailed information about the client.
+   */
+  details: object;
+}
+
+/**
+ * Locations where test results are stored.
+ *
+ * @public
+ */
+export interface ResultStorage {
+  /**
+   * Tool Results history resource containing test results. Format is
+   * `projects/{project_id}/histories/{history_id}`.
+   * See https://firebase.google.com/docs/test-lab/reference/toolresults/rest
+   * for more information.
+   */
+  toolResultsHistory: string;
+
+  /**
+   * Tool Results execution resource containing test results. Format is
+   * `projects/{project_id}/histories/{history_id}/executions/{execution_id}`.
+   * Optional, can be omitted in erroneous test states.
+   * See https://firebase.google.com/docs/test-lab/reference/toolresults/rest
+   * for more information.
+   */
+  toolResultsExecution: string;
+
+  /**
+   * URI to the test results in the Firebase Web Console.
+   */
+  resultsUri: string;
+
+  /**
+   * Location in Google Cloud Storage where test results are written to.
+   * In the form "gs://bucket/path/to/somewhere".
+   */
+  gcsPath: string;
+}


### PR DESCRIPTION
This commit adds the output of the experiment/generate_cloudevents pipeline to the nodejs FunctionsFrameworks. This adds type interfaces for all known Google CloudEvent payloads, but it does not make any changes to the FFs to consume them yet. Those changes will be made in a subsequent PR.

All the types added by this PR can be deleted once the npm packages produced by googleapis/google-cloudevents-nodejs is ready for production usage.