### PR TITLE
refactor: move the bin entrypoint out of index.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "build/src/**/*.d.ts"
   ],
   "bin": {
-    "functions-framework": "./build/src/index.js",
-    "functions-framework-nodejs": "./build/src/index.js"
+    "functions-framework": "./build/src/main.js",
+    "functions-framework-nodejs": "./build/src/main.js"
   },
   "author": "Google Inc.",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 // Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {main} from './main';
-
 /**
  * @public
  */
@@ -25,6 +21,3 @@ export * from './functions';
  * @public
  */
 export {http, cloudevent} from './function_registry';
-
-// Call the main method to load the user code and start the http server.
-main();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,3 +66,6 @@ export const main = async () => {
     throw e;
   }
 };
+
+// Call the main method to load the user code and start the http server.
+main();


### PR DESCRIPTION
This commit moves the call to bootstrap the express server out of
index.ts. This is an important change now that we have declarative
function signatures because we expect developers to include an import
statement for the functions-framework. Before this change doing so would
have automatically started the express http server which makes it hard
to do things like write unit tests.

Fixes #350 