### PR TITLE
ci: add basic validation for declarative function names

### DIFF
--- a/src/function_registry.ts
+++ b/src/function_registry.ts
@@ -44,9 +44,11 @@ const register = (
 };
 
 /**
- * Returns true if the function name is valid (lowercase alphanumeric, numbers, or dash characters).
- * Does not check for beginning or ending with a dash.
- * Does not check for length <= 63 characters.
+ * Returns true if the function name is valid
+ * - must contain only alphanumeric, numbers, or dash characters
+ * - must be <= 63 characters
+ * - must start with a letter
+ * - must end with a letter or number
  * @param functionName the function name
  * @returns true if the function name is valid
  */

--- a/src/function_registry.ts
+++ b/src/function_registry.ts
@@ -33,11 +33,28 @@ const register = (
   signatureType: SignatureType,
   userFunction: HandlerFunction
 ): void => {
+  if (!isValidFunctionName(functionName)) {
+    throw new Error(`Invalid function name: ${functionName}`);
+  }
+
   registrationContainer.set(functionName, {
     signatureType,
     userFunction,
   });
 };
+
+/**
+ * Returns true if the function name is valid (lowercase alphanumeric or dash characters).
+ * Does not check for beginning or ending with a dash.
+ * Does not check for length <= 63 characters.
+ * @param functionName the function name
+ * @returns true if the function name is valid
+ */
+export const isValidFunctionName = (functionName: string): boolean => {
+  // Validate function name with alpha characters, numbers, and dashes
+  const regex = /^[a-zA-Z-]+$/;
+  return regex.test(functionName);
+}
 
 /**
  * Get a declaratively registered function

--- a/src/function_registry.ts
+++ b/src/function_registry.ts
@@ -44,17 +44,17 @@ const register = (
 };
 
 /**
- * Returns true if the function name is valid (lowercase alphanumeric or dash characters).
+ * Returns true if the function name is valid (lowercase alphanumeric, numbers, or dash characters).
  * Does not check for beginning or ending with a dash.
  * Does not check for length <= 63 characters.
  * @param functionName the function name
  * @returns true if the function name is valid
  */
 export const isValidFunctionName = (functionName: string): boolean => {
-  // Validate function name with alpha characters, numbers, and dashes
-  const regex = /^[a-zA-Z-]+$/;
+  // Validate function name with alpha characters, and dashes
+  const regex = /^[a-zA-Z0-9-]+$/;
   return regex.test(functionName);
-}
+};
 
 /**
  * Get a declaratively registered function

--- a/src/function_registry.ts
+++ b/src/function_registry.ts
@@ -52,7 +52,7 @@ const register = (
  */
 export const isValidFunctionName = (functionName: string): boolean => {
   // Validate function name with alpha characters, and dashes
-  const regex = /^[a-zA-Z0-9-]+$/;
+  const regex = /^[A-Za-z](?:[-_A-Za-z0-9]{0,61}[A-Za-z0-9])?$/;
   return regex.test(functionName);
 };
 

--- a/test/function_registry.ts
+++ b/test/function_registry.ts
@@ -33,26 +33,18 @@ describe('function_registry', () => {
 
   it('throws an error if you try to register a function with an invalid URL', () => {
     // Valid function names
-    const validFunctions = [
-      'httpFunction',
-      'ceFunction',
-      'test-func',
-    ];
-    validFunctions.forEach((functionName) => {
+    const validFunctions = ['httpFunction', 'ceFunction', 'test-func'];
+    validFunctions.forEach(functionName => {
       assert.doesNotThrow(() => {
-        FunctionRegistry.http(functionName, () => 'OK')
+        FunctionRegistry.http(functionName, () => 'OK');
       });
     });
 
     // Invalid function names
-    const invalidFunctions = [
-      '',
-      'foo bar',
-      'ស្ថានីយ',
-    ];
-    invalidFunctions.forEach((functionName) => {
+    const invalidFunctions = ['', 'foo bar', 'ស្ថានីយ'];
+    invalidFunctions.forEach(functionName => {
       assert.throws(() => {
-        FunctionRegistry.http(functionName, () => 'OK')
+        FunctionRegistry.http(functionName, () => 'OK');
       });
     });
   });

--- a/test/function_registry.ts
+++ b/test/function_registry.ts
@@ -40,7 +40,7 @@ describe('function_registry', () => {
     ];
     validFunctions.forEach((functionName) => {
       assert.doesNotThrow(() => {
-        FunctionRegistry.http(functionName, () => 'FAIL')
+        FunctionRegistry.http(functionName, () => 'OK')
       });
     });
 
@@ -52,7 +52,7 @@ describe('function_registry', () => {
     ];
     invalidFunctions.forEach((functionName) => {
       assert.throws(() => {
-        FunctionRegistry.http(functionName, () => 'FAIL')
+        FunctionRegistry.http(functionName, () => 'OK')
       });
     });
   });

--- a/test/function_registry.ts
+++ b/test/function_registry.ts
@@ -30,4 +30,30 @@ describe('function_registry', () => {
     assert.deepStrictEqual('cloudevent', signatureType);
     assert.deepStrictEqual((userFunction as () => string)(), 'CE_PASS');
   });
+
+  it('throws an error if you try to register a function with an invalid URL', () => {
+    // Valid function names
+    const validFunctions = [
+      'httpFunction',
+      'ceFunction',
+      'test-func',
+    ];
+    validFunctions.forEach((functionName) => {
+      assert.doesNotThrow(() => {
+        FunctionRegistry.http(functionName, () => 'FAIL')
+      });
+    });
+
+    // Invalid function names
+    const invalidFunctions = [
+      '',
+      'foo bar',
+      'ស្ថានីយ',
+    ];
+    invalidFunctions.forEach((functionName) => {
+      assert.throws(() => {
+        FunctionRegistry.http(functionName, () => 'FAIL')
+      });
+    });
+  });
 });


### PR DESCRIPTION
Adds basic function name validation for registered functions. As almost any sequence of strings can be URL encoded into a valid URL when URL encoded, we check for valid function names using a regex.

Fixes https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/388