### PR TITLE
feat!: update to latest version of clouevents sdk

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,9 +12,9 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '16'
+        node-version: '14'
     - name: Install dependencies
-      run: npm install
+      run: npm ci
     - name: Build docs
       run: npm run docs
     - name: Ensure there are no changes in docs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
           registry-url: 'https://wombat-dressing-room.appspot.com'
       - id: publish
         env:

--- a/docs/generated/api.json
+++ b/docs/generated/api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.19",
+    "toolVersion": "7.18.20",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
@@ -180,7 +180,7 @@
             },
             {
               "kind": "Content",
-              "text": "(functionName: string, handler: "
+              "text": "<T = unknown>(functionName: string, handler: "
             },
             {
               "kind": "Reference",
@@ -189,7 +189,7 @@
             },
             {
               "kind": "Content",
-              "text": ") => void"
+              "text": "<T>) => void"
             }
           ],
           "releaseTag": "Public",
@@ -206,10 +206,31 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare interface CloudEventFunction "
+              "text": "export interface CloudEventFunction<T = "
+            },
+            {
+              "kind": "Content",
+              "text": "unknown"
+            },
+            {
+              "kind": "Content",
+              "text": "> "
             }
           ],
           "releaseTag": "Public",
+          "typeParameters": [
+            {
+              "typeParameterName": "T",
+              "constraintTokenRange": {
+                "startIndex": 0,
+                "endIndex": 0
+              },
+              "defaultTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
           "name": "CloudEventFunction",
           "members": [
             {
@@ -228,6 +249,10 @@
                 },
                 {
                   "kind": "Content",
+                  "text": "<T>"
+                },
+                {
+                  "kind": "Content",
                   "text": "): "
                 },
                 {
@@ -240,8 +265,8 @@
                 }
               ],
               "returnTypeTokenRange": {
-                "startIndex": 3,
-                "endIndex": 4
+                "startIndex": 4,
+                "endIndex": 5
               },
               "releaseTag": "Public",
               "overloadIndex": 1,
@@ -250,7 +275,7 @@
                   "parameterName": "cloudEvent",
                   "parameterTypeTokenRange": {
                     "startIndex": 1,
-                    "endIndex": 2
+                    "endIndex": 3
                   }
                 }
               ]
@@ -265,10 +290,31 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare interface CloudEventFunctionWithCallback "
+              "text": "export interface CloudEventFunctionWithCallback<T = "
+            },
+            {
+              "kind": "Content",
+              "text": "unknown"
+            },
+            {
+              "kind": "Content",
+              "text": "> "
             }
           ],
           "releaseTag": "Public",
+          "typeParameters": [
+            {
+              "typeParameterName": "T",
+              "constraintTokenRange": {
+                "startIndex": 0,
+                "endIndex": 0
+              },
+              "defaultTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
           "name": "CloudEventFunctionWithCallback",
           "members": [
             {
@@ -284,6 +330,10 @@
                   "kind": "Reference",
                   "text": "CloudEvent",
                   "canonicalReference": "cloudevents!CloudEventV1:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<T>"
                 },
                 {
                   "kind": "Content",
@@ -308,8 +358,8 @@
                 }
               ],
               "returnTypeTokenRange": {
-                "startIndex": 5,
-                "endIndex": 6
+                "startIndex": 6,
+                "endIndex": 7
               },
               "releaseTag": "Public",
               "overloadIndex": 1,
@@ -318,14 +368,14 @@
                   "parameterName": "cloudEvent",
                   "parameterTypeTokenRange": {
                     "startIndex": 1,
-                    "endIndex": 2
+                    "endIndex": 3
                   }
                 },
                 {
                   "parameterName": "callback",
                   "parameterTypeTokenRange": {
-                    "startIndex": 3,
-                    "endIndex": 4
+                    "startIndex": 4,
+                    "endIndex": 5
                   }
                 }
               ]
@@ -340,7 +390,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare interface CloudFunctionsContext "
+              "text": "export interface CloudFunctionsContext "
             }
           ],
           "releaseTag": "Public",
@@ -478,6 +528,10 @@
             },
             {
               "kind": "Content",
+              "text": "<unknown>"
+            },
+            {
+              "kind": "Content",
               "text": ";"
             }
           ],
@@ -485,7 +539,7 @@
           "name": "Context",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 4
+            "endIndex": 5
           }
         },
         {
@@ -495,7 +549,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare interface Data "
+              "text": "export interface Data "
             }
           ],
           "releaseTag": "Public",
@@ -537,7 +591,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare interface EventFunction "
+              "text": "export interface EventFunction "
             }
           ],
           "releaseTag": "Public",
@@ -611,7 +665,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare interface EventFunctionWithCallback "
+              "text": "export interface EventFunctionWithCallback "
             }
           ],
           "releaseTag": "Public",
@@ -701,7 +755,15 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare type HandlerFunction = "
+              "text": "export declare type HandlerFunction<T = "
+            },
+            {
+              "kind": "Content",
+              "text": "unknown"
+            },
+            {
+              "kind": "Content",
+              "text": "> = "
             },
             {
               "kind": "Reference",
@@ -737,7 +799,7 @@
             },
             {
               "kind": "Content",
-              "text": " | "
+              "text": "<T> | "
             },
             {
               "kind": "Reference",
@@ -746,14 +808,31 @@
             },
             {
               "kind": "Content",
+              "text": "<T>"
+            },
+            {
+              "kind": "Content",
               "text": ";"
             }
           ],
           "releaseTag": "Public",
           "name": "HandlerFunction",
+          "typeParameters": [
+            {
+              "typeParameterName": "T",
+              "constraintTokenRange": {
+                "startIndex": 0,
+                "endIndex": 0
+              },
+              "defaultTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
           "typeTokenRange": {
-            "startIndex": 1,
-            "endIndex": 10
+            "startIndex": 3,
+            "endIndex": 13
           }
         },
         {
@@ -793,7 +872,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare interface HttpFunction "
+              "text": "export interface HttpFunction "
             }
           ],
           "releaseTag": "Public",
@@ -810,8 +889,8 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Request_2",
-                  "canonicalReference": "@google-cloud/functions-framework!~Request_2:interface"
+                  "text": "Request",
+                  "canonicalReference": "@google-cloud/functions-framework!Request:interface"
                 },
                 {
                   "kind": "Content",
@@ -819,8 +898,8 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "Response_2",
-                  "canonicalReference": "@google-cloud/functions-framework!~Response_2:type"
+                  "text": "Response",
+                  "canonicalReference": "@types/express!~e.Response:interface"
                 },
                 {
                   "kind": "Content",
@@ -903,7 +982,7 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "export declare interface LegacyEvent "
+              "text": "export interface LegacyEvent "
             }
           ],
           "releaseTag": "Public",
@@ -972,11 +1051,11 @@
           "excerptTokens": [
             {
               "kind": "Content",
-              "text": "declare interface Request_2 extends "
+              "text": "export interface Request extends "
             },
             {
               "kind": "Reference",
-              "text": "express.Request",
+              "text": "ExpressRequest",
               "canonicalReference": "@types/express!~e.Request:interface"
             },
             {
@@ -1021,32 +1100,6 @@
               "endIndex": 3
             }
           ]
-        },
-        {
-          "kind": "TypeAlias",
-          "canonicalReference": "@google-cloud/functions-framework!Response_2:type",
-          "docComment": "/**\n * @public\n */\n",
-          "excerptTokens": [
-            {
-              "kind": "Content",
-              "text": "declare type Response_2 = "
-            },
-            {
-              "kind": "Reference",
-              "text": "express.Response",
-              "canonicalReference": "@types/express!~e.Response:interface"
-            },
-            {
-              "kind": "Content",
-              "text": ";"
-            }
-          ],
-          "releaseTag": "Public",
-          "name": "Response_2",
-          "typeTokenRange": {
-            "startIndex": 1,
-            "endIndex": 2
-          }
         }
       ]
     }

--- a/docs/generated/api.md
+++ b/docs/generated/api.md
@@ -7,23 +7,24 @@
 /// <reference types="node" />
 
 import { CloudEventV1 as CloudEvent } from 'cloudevents';
-import * as express from 'express';
+import { Request as Request_3 } from 'express';
+import { Response as Response_2 } from 'express';
 
 export { CloudEvent }
 
 // @public
-export const cloudEvent: (functionName: string, handler: CloudEventFunction) => void;
+export const cloudEvent: <T = unknown>(functionName: string, handler: CloudEventFunction<T>) => void;
 
 // @public
-export interface CloudEventFunction {
+export interface CloudEventFunction<T = unknown> {
     // (undocumented)
-    (cloudEvent: CloudEvent): any;
+    (cloudEvent: CloudEvent<T>): any;
 }
 
 // @public
-export interface CloudEventFunctionWithCallback {
+export interface CloudEventFunctionWithCallback<T = unknown> {
     // (undocumented)
-    (cloudEvent: CloudEvent, callback: Function): any;
+    (cloudEvent: CloudEvent<T>, callback: Function): any;
 }
 
 // @public
@@ -37,7 +38,7 @@ export interface CloudFunctionsContext {
 }
 
 // @public
-export type Context = CloudFunctionsContext | CloudEvent;
+export type Context = CloudFunctionsContext | CloudEvent<unknown>;
 
 // @public
 export interface Data {
@@ -58,7 +59,7 @@ export interface EventFunctionWithCallback {
 }
 
 // @public
-export type HandlerFunction = HttpFunction | EventFunction | EventFunctionWithCallback | CloudEventFunction | CloudEventFunctionWithCallback;
+export type HandlerFunction<T = unknown> = HttpFunction | EventFunction | EventFunctionWithCallback | CloudEventFunction<T> | CloudEventFunctionWithCallback<T>;
 
 // @public
 export const http: (functionName: string, handler: HttpFunction) => void;
@@ -83,13 +84,11 @@ export interface LegacyEvent {
 }
 
 // @public (undocumented)
-interface Request_2 extends express.Request {
+interface Request_2 extends Request_3 {
     rawBody?: Buffer;
 }
 export { Request_2 as Request }
 
-// @public (undocumented)
-type Response_2 = express.Response;
 export { Response_2 as Response }
 
 // (No @packageDocumentation comment for this package)

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,15 +102,15 @@
       "dev": true
     },
     "@microsoft/api-extractor": {
-      "version": "7.18.19",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.18.19.tgz",
-      "integrity": "sha512-aY+/XR7PtQXtnqNPFRs3/+iVRlQJpo6uLTjO2g7PqmnMywl3GBU3bCgAlV/khZtAQbIs6Le57XxmSE6rOqbcfg==",
+      "version": "7.18.20",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.18.20.tgz",
+      "integrity": "sha512-JBstlWs5/MC1IiXSMAwOUnX1hV/IcCl75xF6OUhR2LB7ckZWcsKIbhLecjHC+TZRQsRqVGA3u+DJgB7BIWWYcA==",
       "dev": true,
       "requires": {
-        "@microsoft/api-extractor-model": "7.13.16",
+        "@microsoft/api-extractor-model": "7.13.17",
         "@microsoft/tsdoc": "0.13.2",
         "@microsoft/tsdoc-config": "~0.15.2",
-        "@rushstack/node-core-library": "3.43.2",
+        "@rushstack/node-core-library": "3.44.0",
         "@rushstack/rig-package": "0.3.5",
         "@rushstack/ts-command-line": "4.10.4",
         "colors": "~1.2.1",
@@ -133,14 +133,14 @@
       }
     },
     "@microsoft/api-extractor-model": {
-      "version": "7.13.16",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.13.16.tgz",
-      "integrity": "sha512-ttdxVXsTWL5dd26W1YNLe3LgDsE0EE273aZlcLe58W0opymBybCYU1Mn+OHQM8BuErrdvdN8LdpWAAbkiOEN/Q==",
+      "version": "7.13.17",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.13.17.tgz",
+      "integrity": "sha512-XKP2NsUm2asriB6DshODfSRxYXwSBnA2VA51dVgxJnUE0OnBSZTc2rwzN6mDUJT72JGN081QG99eWA2SutOjIg==",
       "dev": true,
       "requires": {
         "@microsoft/tsdoc": "0.13.2",
         "@microsoft/tsdoc-config": "~0.15.2",
-        "@rushstack/node-core-library": "3.43.2"
+        "@rushstack/node-core-library": "3.44.0"
       }
     },
     "@microsoft/tsdoc": {
@@ -200,9 +200,9 @@
       }
     },
     "@rushstack/node-core-library": {
-      "version": "3.43.2",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.43.2.tgz",
-      "integrity": "sha512-b7AEhSf6CvZgvuDcWMFDeKx2mQSn9AVnMQVyxNxFeHCtLz3gJicqCOlw2GOXM8HKh6PInLdil/NVCDcstwSrIw==",
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.44.0.tgz",
+      "integrity": "sha512-J+w5efSJjitZoxgtBfU4al0FUx2VIcxpPFUxjIvk7Os2hlGV0VxXLUQWIWdiSL6OGxMSksDlHC9/SHcvBARuvg==",
       "dev": true,
       "requires": {
         "@types/node": "12.20.24",
@@ -395,9 +395,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.17.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.31.tgz",
-      "integrity": "sha512-MUeD1RfIycvO6Msfdl4vzfce7r0FWimF8QFdY1XslfHMFYmUvcZDPkaYrqdVLOi9pugnO4ASHyThb2K4hbjxMA==",
+      "version": "14.14.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1025,9 +1025,9 @@
       }
     },
     "cloudevents": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cloudevents/-/cloudevents-5.0.0.tgz",
-      "integrity": "sha512-ximOtbqCaOfSAqkkP0AwG5nIunNuCzNEADXVNW9FSmmOCDxab234NOpJsZovMx6j/COo2p3hwGDcbSS8LN/l1w==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cloudevents/-/cloudevents-5.1.0.tgz",
+      "integrity": "sha512-hCSBp4a46htGbxWSk8PoOv8HsT16uUG1077k82Eje9hTkU8m2xdYZGeTfxEgN7qw0br3tQPxGL++Y7t9m3oHNA==",
       "requires": {
         "ajv": "~6.12.3",
         "uuid": "~8.3.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "body-parser": "^1.18.3",
-    "cloudevents": "^5.0.0",
+    "cloudevents": "^5.1.0",
     "express": "^4.16.4",
     "minimist": "^1.2.5",
     "on-finished": "^2.3.0",
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "test": "mocha build/test --recursive",
-    "build": "npm run clean && npm run compile && npm run docs",
+    "build": "npm run clean && npm run compile",
     "conformance": "./run_conformance_tests.sh",
     "check": "gts check",
     "clean": "gts clean",
@@ -45,12 +45,12 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.18.16",
+    "@microsoft/api-extractor": "^7.18.20",
     "@types/body-parser": "1.19.1",
     "@types/express": "4.17.13",
     "@types/minimist": "1.2.2",
     "@types/mocha": "9.0.0",
-    "@types/node": "14.17.31",
+    "@types/node": "14.14.31",
     "@types/on-finished": "2.3.1",
     "@types/semver": "^7.3.6",
     "@types/sinon": "^10.0.0",
@@ -60,6 +60,6 @@
     "pack-n-play": "^1.0.0-2",
     "sinon": "^11.0.0",
     "supertest": "6.1.6",
-    "typescript": "^4.4.4"
+    "typescript": "4.4.4"
   }
 }

--- a/src/cloud_events.ts
+++ b/src/cloud_events.ts
@@ -56,11 +56,15 @@ export function isBinaryCloudEvent(req: express.Request): boolean {
  * @param req Express request object.
  * @return CloudEvents context.
  */
-export function getBinaryCloudEventContext(req: express.Request): CloudEvent {
-  const context = {} as CloudEvent;
+export function getBinaryCloudEventContext(
+  req: express.Request
+): CloudEvent<unknown> {
+  const context = {} as CloudEvent<unknown>;
   for (const name in req.headers) {
     if (name.startsWith('ce-')) {
-      const attributeName = name.substr('ce-'.length) as keyof CloudEvent;
+      const attributeName = name.substr(
+        'ce-'.length
+      ) as keyof CloudEvent<unknown>;
       context[attributeName] = req.header(name);
     }
   }

--- a/src/function_registry.ts
+++ b/src/function_registry.ts
@@ -15,23 +15,24 @@
 import {HttpFunction, CloudEventFunction, HandlerFunction} from './functions';
 import {SignatureType} from './types';
 
-interface RegisteredFunction {
+interface RegisteredFunction<T> {
   signatureType: SignatureType;
-  userFunction: HandlerFunction;
+  userFunction: HandlerFunction<T>;
 }
 
 /**
  * Singleton map to hold the registered functions
  */
-const registrationContainer = new Map<string, RegisteredFunction>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const registrationContainer = new Map<string, RegisteredFunction<any>>();
 
 /**
  * Helper method to store a registered function in the registration container
  */
-const register = (
+const register = <T = unknown>(
   functionName: string,
   signatureType: SignatureType,
-  userFunction: HandlerFunction
+  userFunction: HandlerFunction<T>
 ): void => {
   if (!isValidFunctionName(functionName)) {
     throw new Error(`Invalid function name: ${functionName}`);
@@ -66,7 +67,8 @@ export const isValidFunctionName = (functionName: string): boolean => {
  */
 export const getRegisteredFunction = (
   functionName: string
-): RegisteredFunction | undefined => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): RegisteredFunction<any> | undefined => {
   return registrationContainer.get(functionName);
 };
 
@@ -86,9 +88,9 @@ export const http = (functionName: string, handler: HttpFunction): void => {
  * @param handler - the function to trigger when handling CloudEvents
  * @public
  */
-export const cloudEvent = (
+export const cloudEvent = <T = unknown>(
   functionName: string,
-  handler: CloudEventFunction
+  handler: CloudEventFunction<T>
 ): void => {
   register(functionName, 'cloudevent', handler);
 };

--- a/src/function_wrappers.ts
+++ b/src/function_wrappers.ts
@@ -60,7 +60,7 @@ const getOnDoneCallback = (res: Response): OnDoneCallback => {
  * @param req an Express HTTP request
  * @returns a CloudEvent parsed from the request
  */
-const parseCloudEventRequest = (req: Request): CloudEvent => {
+const parseCloudEventRequest = (req: Request): CloudEvent<unknown> => {
   let cloudEvent = req.body;
   if (isBinaryCloudEvent(req)) {
     cloudEvent = getBinaryCloudEventContext(req);
@@ -200,8 +200,8 @@ const wrapEventFunctionWithCallback = (
  * @param userFunction User's function.
  * @return An Express hander function that invokes the user function.
  */
-export const wrapUserFunction = (
-  userFunction: HandlerFunction,
+export const wrapUserFunction = <T = unknown>(
+  userFunction: HandlerFunction<T>,
   signatureType: SignatureType
 ): RequestHandler => {
   switch (signatureType) {

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -16,7 +16,7 @@
 // **If changing files, please change package.json!**
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import * as express from 'express';
+import {Request as ExpressRequest, Response} from 'express';
 import {CloudEventV1 as CloudEvent} from 'cloudevents';
 
 /**
@@ -27,7 +27,7 @@ export {CloudEvent};
 /**
  * @public
  */
-export interface Request extends express.Request {
+export interface Request extends ExpressRequest {
   /**
    * A buffer which provides access to the request's raw HTTP body.
    */
@@ -37,7 +37,7 @@ export interface Request extends express.Request {
 /**
  * @public
  */
-export type Response = express.Response;
+export {Response};
 
 /**
  * A HTTP function handler.
@@ -64,26 +64,26 @@ export interface EventFunctionWithCallback {
  * A CloudEvent function handler.
  * @public
  */
-export interface CloudEventFunction {
-  (cloudEvent: CloudEvent): any;
+export interface CloudEventFunction<T = unknown> {
+  (cloudEvent: CloudEvent<T>): any;
 }
 /**
  * A CloudEvent function handler with callback.
  * @public
  */
-export interface CloudEventFunctionWithCallback {
-  (cloudEvent: CloudEvent, callback: Function): any;
+export interface CloudEventFunctionWithCallback<T = unknown> {
+  (cloudEvent: CloudEvent<T>, callback: Function): any;
 }
 /**
  * A function handler.
  * @public
  */
-export type HandlerFunction =
+export type HandlerFunction<T = unknown> =
   | HttpFunction
   | EventFunction
   | EventFunctionWithCallback
-  | CloudEventFunction
-  | CloudEventFunctionWithCallback;
+  | CloudEventFunction<T>
+  | CloudEventFunctionWithCallback<T>;
 
 /**
  * A legacy event.
@@ -136,4 +136,4 @@ export interface CloudFunctionsContext {
  * The function's context.
  * @public
  */
-export type Context = CloudFunctionsContext | CloudEvent;
+export type Context = CloudFunctionsContext | CloudEvent<unknown>;

--- a/test/function_wrappers.ts
+++ b/test/function_wrappers.ts
@@ -77,12 +77,15 @@ describe('wrapUserFunction', () => {
   it('correctly wraps an async CloudEvent function', done => {
     const request = createRequest(CLOUD_EVENT);
     const response = createResponse();
-    const func = wrapUserFunction(async (cloudEvent: CloudEvent) => {
-      assert.deepStrictEqual(cloudEvent, CLOUD_EVENT);
-      // await to make sure wrapper handles async code
-      await new Promise(resolve => setTimeout(resolve, 20));
-      done();
-    }, 'cloudevent');
+    const func = wrapUserFunction(
+      async (cloudEvent: CloudEvent<typeof CLOUD_EVENT.data>) => {
+        assert.deepStrictEqual(cloudEvent, CLOUD_EVENT);
+        // await to make sure wrapper handles async code
+        await new Promise(resolve => setTimeout(resolve, 20));
+        done();
+      },
+      'cloudevent'
+    );
     func(request, response, () => {});
   });
 
@@ -90,7 +93,7 @@ describe('wrapUserFunction', () => {
     const request = createRequest(CLOUD_EVENT);
     const response = createResponse();
     const func = wrapUserFunction(
-      (cloudEvent: CloudEvent, callback: Function) => {
+      (cloudEvent: CloudEvent<typeof CLOUD_EVENT.data>, callback: Function) => {
         // timeout to make sure wrapper waits for callback
         setTimeout(() => {
           assert.deepStrictEqual(cloudEvent, CLOUD_EVENT);


### PR DESCRIPTION
This commit updates to the latest CESDK which provides a generic interface for CloudEvents. This is an additive, non-breaking change to our registration API:

providing a template type on the registration function:

```typescript
import * as functions from '@google-cloud/functions-framework';

functions.cloudEvent<string>('helloTypes', (ce) => {
  // the event data is strongly typed here
  ce.data.length;
});
```
providing a template type on the argument annotation:

```typescript
import {CloudEvent}, * as functions from '@google-cloud/functions-framework';

functions.cloudEvent('helloTypes', (ce: CloudEvent<string>) => {
  // the event data is strongly typed here
  ce.data.length;
});
```

not providing a template is still allowed:

```typescript
import functions from '@google-cloud/functions-framework';

functions.cloudEvent('helloTypes', (ce) => {
  // the event data has type "unknown" by default so the customer can cast to anything they want 
  const data = ce.data as string;
  data.length; // OK
});
```