### PR TITLE
fix!: fix crash report for cloudevent functions

### DIFF
--- a/src/function_wrappers.ts
+++ b/src/function_wrappers.ts
@@ -48,9 +48,10 @@ const getOnDoneCallback = (res: Response): OnDoneCallback => {
     } else {
       res.locals.functionExecutionFinished = true;
       if (err) {
-        console.error(err.stack);
+        sendCrashResponse({err, res});
+      } else {
+        sendResponse(result, err, res);
       }
-      sendResponse(result, err, res);
     }
   });
 };

--- a/src/function_wrappers.ts
+++ b/src/function_wrappers.ts
@@ -47,6 +47,7 @@ const getOnDoneCallback = (res: Response): OnDoneCallback => {
       console.log('Ignoring extra callback call');
     } else {
       res.locals.functionExecutionFinished = true;
+      // Send crash if there's an error, o.w. send the result.
       if (err) {
         sendCrashResponse({err, res});
       } else {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -44,6 +44,7 @@ export function sendCrashResponse({
   // execution sends the response between the check and 'send' call below.
   if (res && !res.headersSent) {
     res.set(FUNCTION_STATUS_HEADER_FIELD, 'crash');
+    res.status(500);
     res.send((err.message || err) + '');
   }
   if (callback) {

--- a/test/conformance/function.js
+++ b/test/conformance/function.js
@@ -5,7 +5,7 @@ const fileName = 'function_output.json';
 
 functions.http('writeHttpDeclarative', (req, res) => {
   writeJson(req.body);
-  res.end(200);
+  res.status(200).end();
 });
 
 functions.cloudEvent('writeCloudEventDeclarative', cloudEvent => {
@@ -15,7 +15,7 @@ functions.cloudEvent('writeCloudEventDeclarative', cloudEvent => {
 
 function writeHttp(req, res) {
   writeJson(req.body);
-  res.end(200);
+  res.status(200).end();
 }
 
 function writeCloudEvent(cloudEvent) {

--- a/test/logger.ts
+++ b/test/logger.ts
@@ -23,22 +23,16 @@ describe('logger', () => {
       res.send('200, OK!');
     });
     const server = getTestServer('myfunc');
-    await supertest(server)
-      .post('/')
-      .send({})
-      .expect(200);
+    await supertest(server).post('/').send({}).expect(200);
   });
 
   // A normal cloudevent function request should return a 200.
   it('200 cloudevent', async () => {
-    functions.cloudEvent('myfunc', (ce) => {
+    functions.cloudEvent('myfunc', ce => {
       return '200, OK! 204 No Content if no response.';
     });
     const server = getTestServer('myfunc');
-    await supertest(server)
-      .post('/')
-      .send({})
-      .expect(200);
+    await supertest(server).post('/').send({}).expect(200);
   });
 
   // A function that throws a runtime error should return a 500.
@@ -47,21 +41,15 @@ describe('logger', () => {
       throw new Error('500, Internal Server Error!');
     });
     const server = getTestServer('myfunc');
-    await supertest(server)
-      .post('/')
-      .send({})
-      .expect(500);
+    await supertest(server).post('/').send({}).expect(500);
   });
 
   // A function that throws a runtime error should return a 500.
   it('500 cloudevent', async () => {
-    functions.cloudEvent('myfunc', (ce) => {
+    functions.cloudEvent('myfunc', ce => {
       throw new Error('500, Internal Server Error!');
     });
     const server = getTestServer('myfunc');
-    await supertest(server)
-      .post('/')
-      .send({})
-      .expect(500);
+    await supertest(server).post('/').send({}).expect(500);
   });
 });

--- a/test/logger.ts
+++ b/test/logger.ts
@@ -1,0 +1,67 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {getTestServer} from '../src/testing';
+import * as supertest from 'supertest';
+import * as functions from '../src/index';
+
+describe('logger', () => {
+  // A normal http function request should return a 200.
+  it('200 http', async () => {
+    functions.http('myfunc', (req, res) => {
+      res.send('200, OK!');
+    });
+    const server = getTestServer('myfunc');
+    await supertest(server)
+      .post('/')
+      .send({})
+      .expect(200);
+  });
+
+  // A normal cloudevent function request should return a 200.
+  it('200 cloudevent', async () => {
+    functions.cloudEvent('myfunc', (ce) => {
+      return '200, OK! 204 No Content if no response.';
+    });
+    const server = getTestServer('myfunc');
+    await supertest(server)
+      .post('/')
+      .send({})
+      .expect(200);
+  });
+
+  // A function that throws a runtime error should return a 500.
+  it('500 http', async () => {
+    functions.http('myfunc', (req, res) => {
+      throw new Error('500, Internal Server Error!');
+    });
+    const server = getTestServer('myfunc');
+    await supertest(server)
+      .post('/')
+      .send({})
+      .expect(500);
+  });
+
+  // A function that throws a runtime error should return a 500.
+  it('500 cloudevent', async () => {
+    functions.cloudEvent('myfunc', (ce) => {
+      throw new Error('500, Internal Server Error!');
+    });
+    const server = getTestServer('myfunc');
+    await supertest(server)
+      .post('/')
+      .send({})
+      .expect(500);
+  });
+});


### PR DESCRIPTION
Fixes HTTP response code for functions that throw an error within the function.

- Fixes function crash HTTP header
- Adds new test suite for the FF logger

It looks like we were inconsistent with sending a crash response with logic in `src/function_wrappers.ts`.

## Example

Here's an example for how to send and inspect a HTTP response:

```
curl -XPOST http://localhost:8080/ -I
HTTP/1.1 500 Internal Server Error
X-Google-Status: crash
Content-Type: text/html; charset=utf-8
Content-Length: 8
ETag: W/"8-OhraUVTQ47wG45qqkAQ/rn0lV6g"
Date: Fri, 10 Dec 2021 23:58:37 GMT
Connection: keep-alive
Keep-Alive: timeout=5
```

Fixes https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/322