### PR TITLE
docs: add instructions for deploying with typescript codebase

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -54,3 +54,22 @@ the Functions Framework.
     Function: helloWorld
     URL: http://localhost:8080/
     ```
+
+## Deploying with gcloud CLI
+
+1. Adjust `main` field in `package.json` to point to the compiled javascript source. `gcloud` will inspect the `main` field to detect sources:
+    
+    ```js
+      "main": "build/src/index.js",
+      ...
+    ```
+
+2. Remove `prepare` script in `package.json` created by [gts](https://github.com/google/gts). Because this script requires typescript to be installed it will fail when deploying.
+
+3. Deploy:
+
+    ```sh
+    gcloud functions deploy helloWorld \
+    --runtime nodejsXX \ # e.g. nodejs16
+    --trigger-http
+    ```

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -57,19 +57,19 @@ the Functions Framework.
 
 ## Deploying with gcloud CLI
 
-1. Adjust `main` field in `package.json` to point to the compiled javascript source. `gcloud` will inspect the `main` field to detect sources:
+1. Adjust `main` field in `package.json` to point to the compiled javascript source.
     
     ```js
       "main": "build/src/index.js",
       ...
     ```
 
-2. Remove `prepare` script in `package.json` created by [gts](https://github.com/google/gts). Because this script requires typescript to be installed it will fail when deploying.
+1. Remove `prepare` script in `package.json` created by [gts](https://github.com/google/gts). This is because the `prepare` script requires typescript to be installed and will cause the function to fail to deploy if not removed.
 
-3. Deploy:
+1. Deploy:
 
     ```sh
     gcloud functions deploy helloWorld \
-    --runtime nodejsXX \ # e.g. nodejs16
+    --runtime nodejs16 \
     --trigger-http
     ```


### PR DESCRIPTION
Update typescript readme as proposed in [issue](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/254)