### PR TITLE
patching debugging docs

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -19,7 +19,7 @@ npm install @google-cloud/functions-framework
 3. Run `node`, enable the inspector and run the Functions Framework:
 
 ```sh
-node --inspect node_modules/@google-cloud/functions-framework --target=helloWorld
+node --inspect node_modules/.bin/functions-framework --target=helloWorld
 ...
 Debugger listening on ws://127.0.0.1:9229/5f57f5e9-ea4b-43ce-be1d-6e9b838ade4a
 For help see https://nodejs.org/en/docs/inspector
@@ -27,5 +27,7 @@ Serving function...
 Function: helloWorld
 URL: http://localhost:8080/
 ```
+
+> Note that the [symlinked executable](https://docs.npmjs.com/cli/v8/configuring-npm/folders#executables) of the function framework in  node_modules/**.bin**/functions-framework is used to direct the debugger to the necessary entrypoint.
 
 You can now use an IDE or other tooling to add breakpoints, step through your code and debug your function.


### PR DESCRIPTION
After #377 adopting the entrypoint to ./build/src/main.js, the Node Inspector does not work as expected. 

By pointing on the symlinked executable in node_modules/.bin/functions-framework (which is reflecting the right entry point) someone can use the functions framework in conjunction with the node inspector as expected. 