### PR TITLE
fix: update crash status with 500

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -44,6 +44,7 @@ export function sendCrashResponse({
   // execution sends the response between the check and 'send' call below.
   if (res && !res.headersSent) {
     res.set(FUNCTION_STATUS_HEADER_FIELD, 'crash');
+    res.status(500);
     res.send((err.message || err) + '');
   }
   if (callback) {

--- a/test/function_wrappers.ts
+++ b/test/function_wrappers.ts
@@ -105,4 +105,15 @@ describe('wrapUserFunction', () => {
     );
     func(request, response, () => {});
   });
+
+  it('correctly send a 500 for function crashes', done => {
+    const request = createRequest({foo: 'bar'});
+    const response = createResponse();
+    const func = wrapUserFunction((req: Request, res: Response) => {
+      throw new Error('crash');
+    }, 'http');
+    func(request, response, () => {
+      assert.deepStrictEqual(response.statusCode, 500);
+    });
+  });
 });


### PR DESCRIPTION
Send correct error code when there is a function crash.

The CI conformance errors seem unrelated to this change.

```
[/tmp/serverlog_stderr.txt]: 'TypeError [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received type number (200)
```