### PR TITLE
fix!: send correct response code on exception

### DIFF
--- a/src/invoker.ts
+++ b/src/invoker.ts
@@ -21,7 +21,6 @@
 //     functions with HTTP trigger).
 import * as express from 'express';
 import * as http from 'http';
-import {FUNCTION_STATUS_HEADER_FIELD} from './types';
 import {sendCrashResponse} from './logger';
 
 /**
@@ -47,10 +46,7 @@ export function sendResponse(
   res: express.Response
 ) {
   if (err) {
-    res.set(FUNCTION_STATUS_HEADER_FIELD, 'error');
-    // Sending error message back is fine for Pub/Sub-based functions as they do
-    // not reach the caller anyway.
-    res.send(err.message);
+    sendCrashResponse({err, res, statusHeader: 'error'});
     return;
   }
   if (typeof result === 'undefined' || result === null) {

--- a/test/conformance/function.js
+++ b/test/conformance/function.js
@@ -5,7 +5,7 @@ const fileName = 'function_output.json';
 
 functions.http('writeHttpDeclarative', (req, res) => {
   writeJson(req.body);
-  res.end(200);
+  res.sendStatus(200);
 });
 
 functions.cloudEvent('writeCloudEventDeclarative', cloudEvent => {
@@ -15,7 +15,7 @@ functions.cloudEvent('writeCloudEventDeclarative', cloudEvent => {
 
 function writeHttp(req, res) {
   writeJson(req.body);
-  res.end(200);
+  res.sendStatus(200);
 }
 
 function writeCloudEvent(cloudEvent) {


### PR DESCRIPTION
This commit updates the http response we send when the customer's function throws to:

1. always send a 500 HTTP status
2. strip the error message from the response body when running in production