### PR TITLE
docs: improve docs using npx for debugging

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -19,7 +19,7 @@ npm install @google-cloud/functions-framework
 3. Run `node`, enable the inspector and run the Functions Framework:
 
 ```sh
-node --inspect node_modules/.bin/functions-framework --target=helloWorld
+npx --node-options=--inspect @google-cloud/functions-framework --target=helloWorld
 ...
 Debugger listening on ws://127.0.0.1:9229/5f57f5e9-ea4b-43ce-be1d-6e9b838ade4a
 For help see https://nodejs.org/en/docs/inspector


### PR DESCRIPTION
Uses `npx` for the debugging docs. Might help with windows users. Using the `.bin` folder directly seem finicky.

See: https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/15#issuecomment-1036834366

Tested locally with the [debugging docs](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/master/docs/debugging.md):

```
npx --node-options=--inspect @google-cloud/functions-framework --target=helloWorld
Debugger listening on ws://127.0.0.1:9229/0f8f426d-8456-453d-887b-e34612cc872f
For help, see: https://nodejs.org/en/docs/inspector
Serving function...
Function: helloWorld
Signature type: http
URL: http://localhost:8080/
```