### PR TITLE
Disable Express eTag response header for consistent FF behaviour across FF runtimes 

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -96,6 +96,8 @@ export function getServer(
   // Disable Express 'x-powered-by' header:
   // http://expressjs.com/en/advanced/best-practice-security.html#at-a-minimum-disable-x-powered-by-header
   app.disable('x-powered-by');
+  // Disable Express eTag response header
+  app.disable('etag'); 
 
   if (
     functionSignatureType === 'event' ||

--- a/src/server.ts
+++ b/src/server.ts
@@ -93,9 +93,11 @@ export function getServer(
   // Subsequent parsers will be skipped when one is matched.
   app.use(bodyParser.raw(rawBodySavingOptions));
   app.enable('trust proxy'); // To respect X-Forwarded-For header.
+  
   // Disable Express 'x-powered-by' header:
   // http://expressjs.com/en/advanced/best-practice-security.html#at-a-minimum-disable-x-powered-by-header
   app.disable('x-powered-by');
+  
   // Disable Express eTag response header
   app.disable('etag'); 
 


### PR DESCRIPTION
The Express.js framework handles [eTags] (https://expressjs.com/en/api.html#app.settings.table) by default. Therefore, will respond with HTTP 304 Not Modified when a known eTag header value is present in a request with the same response.

In all other Function Framework runtime implementations, this behavior is not  implemented, and this caching behavior, which can be considered as an implementation detail, could be explicitly addressed by a developer as needed.

This pull request aims make the NodeJs runtime version behaving the same as runtime implementations for GO, Java, Ruby, .Net Core, Python, and PHP.