### PR TITLE
chore: do not renovate docs/experimental folders

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,10 @@
       "automerge": true
     }
   ],
+  "ignorePaths": [
+    "docs/**",
+    "experimental/**"
+  ],
   "pinVersions": false,
   "schedule": [
     "every 3 months on the first day of the month"


### PR DESCRIPTION
We don't need to keep having PRs update deps in docs or experimental folders.