### PR TITLE
Revert "Disable Express eTag response header for consistent FF behaviour across FF runtimes "

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -93,13 +93,9 @@ export function getServer(
   // Subsequent parsers will be skipped when one is matched.
   app.use(bodyParser.raw(rawBodySavingOptions));
   app.enable('trust proxy'); // To respect X-Forwarded-For header.
-  
   // Disable Express 'x-powered-by' header:
   // http://expressjs.com/en/advanced/best-practice-security.html#at-a-minimum-disable-x-powered-by-header
   app.disable('x-powered-by');
-  
-  // Disable Express eTag response header
-  app.disable('etag'); 
 
   if (
     functionSignatureType === 'event' ||


### PR DESCRIPTION
Reverts GoogleCloudPlatform/functions-framework-nodejs#433 due to failed lint check.