### PR TITLE
chore: update renovate match rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,12 @@
     "description": "Create a PR whenever there is a new major version",
     "matchUpdateTypes": ["major"]
   }],
+  "patch": {
+    "enabled": false
+  },
+  "minor": {
+    "enabled": false
+  },
   "ignorePaths": [
     "docs/**",
     "experimental/**"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,16 +3,26 @@
   "extends": [
     "config:base"
   ],
-  "packageRules": [{
-    "description": "Create a PR whenever there is a new major version",
-    "matchUpdateTypes": ["major"]
-  }],
-  "patch": {
-    "enabled": false
-  },
-  "minor": {
-    "enabled": false
-  },
+  "packageRules": [
+    {
+      "description": "Create a PR whenever there is a new major version",
+      "matchUpdateTypes": [
+        "major"
+      ]
+    },
+    {
+      "description": "Create a PR grouping all non-major dependencies",
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch"
+    }
+  ],
   "ignorePaths": [
     "docs/**",
     "experimental/**"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,13 +1,12 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
   ],
-  "packageRules": [
-    {
-      "updateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
-    }
-  ],
+  "packageRules": [{
+    "description": "Create a PR whenever there is a new major version",
+    "matchUpdateTypes": ["major"]
+  }],
   "ignorePaths": [
     "docs/**",
     "experimental/**"


### PR DESCRIPTION
We have a few too many PRs that are minor/patch versions without significant updates.

This PR adds a schema to the renovate config and sets the package rules to group minor/patch PRs.

Automerge true also didn't work as expected - it is removed here.

References:

- https://docs.renovatebot.com/presets-group/#groupallnonmajor
- https://stackoverflow.com/questions/66471226/renovate-combine-all-updates-to-one-branch-pr

See:

- https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/451
- https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/449
- https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/448
- https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/447
- https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/446
- https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/445
- https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/444
- https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/443
- https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/442
- https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/441
