### PR TITLE
chore: use Release Please GitHub Action

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,0 @@
-releaseType: node
-handleGHRelease: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,11 @@
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node


### PR DESCRIPTION
This is the recommended way to configure
[release-please](https://github.com/googleapis/release-please#setting-up-release-please)
and allows running additional steps before/after for validation.