### PR TITLE
Export Server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@
  * @public
  */
 export * from './functions';
+export * from './server';
 
 /**
  * @public


### PR DESCRIPTION
Add `export * from server` to `index.ts`.

## Use case

I would like to use `@google-cloud/functions-framework` for integration tests of a [Remix](https://remix.run) Firebase functions adapter, to start and stop a functions server during [Playwright](https://playwright.dev) tests.

The existing integration tests for Remix use their Express adapter:

```ts
      let port = await getPort();
      let app = express();
      app.use(express.static(path.join(fixture.projectDir, "public")));
      app.all(
        "*",
        createExpressHandler({ build: fixture.build, mode: "production" })
      );

      let server = app.listen(port);
```
https://github.com/remix-run/remix/blob/6a2bf52d9ca60e2ce6459ebe72df28e6a568ed26/integration/helpers/create-fixture.ts#L97-L121

I would like to run the same tests against a [Firebase adapter I am working on](http://npmjs.com/package/remix-firebase).

The difference between the Express adapter and Firebase adapter is primarily the use of rawBody, and I'd like to ensure the integration tests still succeed given this difference. I need a functions server to use in the integration tests that behaves as per production deployments of Firebase functions.

I can update the above code to the following:

```ts
      let port = await getPort();
      let functionsPort = await getPort();
      let app = express();
      app.use(express.static(path.join(fixture.projectDir, "public")));
      app.all("*", proxy(`localhost:${functionsPort}`));
      let server = app.listen(port);
      let functionsServer = functions.getServer(
        createFirebaseHandler({
          build: fixture.build,
          mode: "production",
        }),
        "http"
      );
      functionsServer.listen(functionsPort);
```

...but this requires access to the `getServer` function.

I looked at other libraries such as the emulators in firebase-tools, but these require the functions to exist as files on disk. In the tests above, the functions need to be created per test using `fixture.build` as an argument.


The `getTestServer` [exported from testing.ts](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/759aac18ad297363c4651efcf19ab2bf8fa9625a/src/testing.ts#L44-L55) has 2 issues preventing me from using it for this purpose:

- TypeScript cannot find the types, and errors with "Cannot find module '@google-cloud/functions-framework/testing' or its corresponding type declarations.ts(2307)"
- It assumes the function exists as a file, and accepts a function name as a string, but as shown in my example code above I need to build and pass the function directly.
