### PR TITLE
Small improvements to CloudEvents docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 This directory contains advanced docs around the Functions Framework.
 
 - [Testing events and Pub/Sub](events.md)
+- [Testing CloudEvents](cloudevents.md)
 - [Testing Functions](testing-functions.md)
 - [Debugging Functions](debugging.md)
 - [Running and Deploying Docker Containers](docker.md)

--- a/docs/cloudevents.md
+++ b/docs/cloudevents.md
@@ -34,7 +34,7 @@ Add a `package.json` script to start the Functions Framework and pass the name o
 ```sh
 {
   "scripts": {
-    "start": "functions-framework --target=helloCloudEvents"
+    "start": "functions-framework --target=helloCloudEvents --signature-type=cloudevent"
   }
 }
 ```
@@ -51,5 +51,5 @@ it is no longer accessible via `HTTP GET` requests from the browser.
 ### Create and Send a CloudEvent to the Function
 
 ```
-cloudevents send http://localhost:8080 --specver--id abc-123 --source cloudevents.conformance.tool --type foo.bar
+cloudevents send http://localhost:8080 --id abc-123 --source cloudevents.conformance.tool --type foo.bar
 ```


### PR DESCRIPTION
- Link to specific subpage from `docs/README.md`.
- Pass `--signature-type=cloudevent` to functions-framework start command.
- Fix `cloudevents` command-line to match example from https://github.com/cloudevents/conformance (just `--id`, not `--specver--id`).