### PR TITLE
chore: update buildpack test

### DIFF
--- a/.github/workflows/buildpack-integration-test.yml
+++ b/.github/workflows/buildpack-integration-test.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   nodejs10:
-    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.4.1
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.8.0
     with:
       http-builder-source: 'test/conformance'
       http-builder-target: 'writeHttpDeclarative'
@@ -15,10 +15,8 @@ jobs:
       cloudevent-builder-target: 'writeCloudEventDeclarative'
       prerun: 'test/conformance/prerun.sh'
       builder-runtime: 'nodejs10'
-      # Latest uploaded tag from us.gcr.io/fn-img/buildpacks/nodejs10/builder
-      builder-tag: 'nodejs10_20220320_10_24_1_RC00'
   nodejs12:
-    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.4.1
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.8.0
     with:
       http-builder-source: 'test/conformance'
       http-builder-target: 'writeHttpDeclarative'
@@ -26,10 +24,8 @@ jobs:
       cloudevent-builder-target: 'writeCloudEventDeclarative'
       prerun: 'test/conformance/prerun.sh'
       builder-runtime: 'nodejs12'
-      # Latest uploaded tag from us.gcr.io/fn-img/buildpacks/nodejs12/builder
-      builder-tag: 'nodejs12_20220320_12_22_9_RC00'
   nodejs14:
-    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.4.1
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.8.0
     with:
       http-builder-source: 'test/conformance'
       http-builder-target: 'writeHttpDeclarative'
@@ -37,10 +33,8 @@ jobs:
       cloudevent-builder-target: 'writeCloudEventDeclarative'
       prerun: 'test/conformance/prerun.sh'
       builder-runtime: 'nodejs14'
-      # Latest uploaded tag from us.gcr.io/fn-img/buildpacks/nodejs16/builder
-      builder-tag: 'nodejs14_20220320_14_18_3_RC00'
   nodejs16:
-    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.4.1
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.8.0
     with:
       http-builder-source: 'test/conformance'
       http-builder-target: 'writeHttpDeclarative'
@@ -48,5 +42,3 @@ jobs:
       cloudevent-builder-target: 'writeCloudEventDeclarative'
       prerun: 'test/conformance/prerun.sh'
       builder-runtime: 'nodejs16'
-      # Latest uploaded tag from us.gcr.io/fn-img/buildpacks/nodejs16/builder
-      builder-tag: 'nodejs16_20220320_16_13_2_RC00'


### PR DESCRIPTION
Newest version of the client does not require a builder-tag and will use "latest" by default.