### PR TITLE
chore: fix publish npm package workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 on:
   release:
     types: [created]
+  workflow_dispatch:
 name: publish
 jobs:
   publish-to-npm:
@@ -9,12 +10,15 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: '16.x'
+      - run: npm install
+      - run: npm run build
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
           registry-url: 'https://wombat-dressing-room.appspot.com'
       - id: publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        run: |
-          npm install
-          npm run build
+        run:
           npm publish


### PR DESCRIPTION
Per instructions for using the publish service

"We take care in this job to set the registry to the publish service after any npm commands that install dependencies (e.g. npm ci), because the publish service is only meant for publishing. If you try to npm install with the publish service registry, it will fail."