### PR TITLE
fix: remove default fallback when target function does not exist

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -121,7 +121,7 @@ export async function getUserFunction(
       return registeredFunction;
     }
 
-    let userFunction = functionTarget
+    const userFunction = functionTarget
       .split('.')
       .reduce((code, functionTargetPart) => {
         if (typeof code === 'undefined') {
@@ -131,18 +131,12 @@ export async function getUserFunction(
         }
       }, functionModule);
 
-    // TODO: do we want 'function' fallback?
     if (typeof userFunction === 'undefined') {
-      // eslint-disable-next-line no-prototype-builtins
-      if (functionModule.hasOwnProperty('function')) {
-        userFunction = functionModule['function'];
-      } else {
-        console.error(
-          `Function '${functionTarget}' is not defined in the provided ` +
-            'module.\nDid you specify the correct target function to execute?'
-        );
-        return null;
-      }
+      console.error(
+        `Function '${functionTarget}' is not defined in the provided ` +
+          'module.\nDid you specify the correct target function to execute?'
+      );
+      return null;
     }
 
     if (typeof userFunction !== 'function') {

--- a/test/loader.ts
+++ b/test/loader.ts
@@ -93,6 +93,20 @@ describe('loading function', () => {
     }
   }
 
+  it('fails to load a function that does not exist', async () => {
+    FunctionRegistry.http('function', () => {
+      return 'PASS';
+    });
+
+    const loadedFunction = await loader.getUserFunction(
+      process.cwd() + '/test/data/with_main',
+      'functionDoesNotExist',
+      'http'
+    );
+
+    assert.strictEqual(loadedFunction, null);
+  });
+
   it('loads a declaratively registered function', async () => {
     FunctionRegistry.http('registeredFunction', () => {
       return 'PASS';


### PR DESCRIPTION
The function framework's current behavior is to load an exported function named 'function' if one exists as a fallback if the user's declared target function is not found. This behavior is counter intuitive and can hide misconfiguration from the user.

In this CL a breaking change is made to disable this fallback behavior in favor of failing fast so that the configuration error is highly visible to the user.