### PR TITLE
fix: make renovatebot's ignorePath and grouping of non-major updates work correctly

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,34 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
+  "globalExtends": [
     "config:base"
   ],
+  "extends": ["group:allNonMajor", "schedule:monthly"],
   "packageRules": [
     {
       "description": "Create a PR whenever there is a new major version",
       "matchUpdateTypes": [
         "major"
       ]
-    },
-    {
-      "description": "Create a PR grouping all non-major dependencies",
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch"
     }
   ],
   "ignorePaths": [
     "docs/**",
     "experimental/**"
   ],
-  "pinVersions": false,
-  "schedule": [
-    "every 3 months on the first day of the month"
-  ]
+  "pinVersions": false
 }


### PR DESCRIPTION
The renovate configs currently in use is not correctly ignoring the docs and experimental folders, and seems to not group non major updates together.

* The previous renovate config ```ignorePaths``` was not working due to a current issue with renovate itself where ```ignorePaths``` is being overwrited by the ```coinfig:base``` defaults. The suggested fix is to use ```globalExtends``` property. Discussion used: https://github.com/renovatebot/renovate/discussions/14793
* Changed config to use the ```group:allNonMajor``` extension which ended up grouping non-major versions correctly.

Tested by forking repo, changing versions manually, and then running a locally cloned renovate bot against my fork with the updated renovate config file.

Example of how non major grouping would look like:
<img width="912" alt="Screenshot 2023-01-09 at 11 43 15 AM" src="https://user-images.githubusercontent.com/22991923/211398188-b7ca25b8-8b01-4472-8a87-d60dacd60555.png">




