### PR TITLE
docs: Update debugging markdown

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -19,7 +19,7 @@ npm install @google-cloud/functions-framework
 3. Run `node`, enable the inspector and run the Functions Framework:
 
 ```sh
-node --inspect node_modules/.bin/functions-framework --target=helloWorld
+node --inspect node_modules/@google-cloud/functions-framework/build/src/main.js --target=helloWorld
 ...
 Debugger listening on ws://127.0.0.1:9229/5f57f5e9-ea4b-43ce-be1d-6e9b838ade4a
 For help see https://nodejs.org/en/docs/inspector
@@ -27,7 +27,5 @@ Serving function...
 Function: helloWorld
 URL: http://localhost:8080/
 ```
-
-> Note that the [symlinked executable](https://docs.npmjs.com/cli/v8/configuring-npm/folders#executables) of the function framework in  node_modules/**.bin**/functions-framework is used to direct the debugger to the necessary entrypoint.
 
 You can now use an IDE or other tooling to add breakpoints, step through your code and debug your function.


### PR DESCRIPTION
Hi, we were trying to debug cloud functions locally, using `functions-framework`. It seems that the doc is out of date, it doesn't work if you point to `.bin` folder

We were testing using:
- Windows 10
- node.js v18.12.1
- cmd console

This is the output we were receiving when we tried to debug it in the way it was documented.

```
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^

SyntaxError: missing ) after argument list
←[90m    at Object.compileFunction (node:vm:360:18)←[39m
←[90m    at wrapSafe (node:internal/modules/cjs/loader:1088:15)←[39m
←[90m    at Module._compile (node:internal/modules/cjs/loader:1123:27)←[39m
←[90m    at Module._extensions..js (node:internal/modules/cjs/loader:1213:10)←[39m
←[90m    at Module.load (node:internal/modules/cjs/loader:1037:32)←[39m
←[90m    at Module._load (node:internal/modules/cjs/loader:878:12)←[39m
←[90m    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)←[39m
←[90m    at node:internal/main/run_main_module:23:47←[39m

Node.js v18.12.1
```

It's related to:
- #420
- #15 (in this one a lot of people were complaining about this error)