### PR TITLE
fix: module resolution returns early and accurate error messages on failure

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -93,7 +93,11 @@ export async function getUserFunction(
   try {
     const functionModulePath = getFunctionModulePath(codeLocation);
     if (functionModulePath === null) {
-      console.error('Provided code is not a loadable module.');
+      console.error(
+        `Provided code location '${codeLocation}' is not a loadable module.` +
+          '\nDid you specify the correct location for the module defining ' +
+          'your function?'
+      );
       return null;
     }
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -174,16 +174,17 @@ export async function getUserFunction(
  * @return Resolved path or null.
  */
 function getFunctionModulePath(codeLocation: string): string | null {
-  let path: string | null = null;
   try {
-    path = require.resolve(codeLocation);
+    return require.resolve(codeLocation);
   } catch (ex) {
-    try {
-      // TODO: Decide if we want to keep this fallback.
-      path = require.resolve(codeLocation + '/function.js');
-    } catch (ex) {
-      return path;
-    }
+    // Ignore exception, this means the function was not found here.
   }
-  return path;
+
+  try {
+    return require.resolve(codeLocation + '/function.js');
+  } catch (ex) {
+    // Ignore exception, this means the function was not found here.
+  }
+
+  return null;
 }

--- a/test/loader.ts
+++ b/test/loader.ts
@@ -93,11 +93,17 @@ describe('loading function', () => {
     }
   }
 
-  it('fails to load a function that does not exist', async () => {
-    FunctionRegistry.http('function', () => {
-      return 'PASS';
-    });
+  it('fails to load a module that does not exist', async () => {
+    const loadedFunction = await loader.getUserFunction(
+      process.cwd() + '/test/data/does_not_exist',
+      'functionDoesNotExist',
+      'http'
+    );
 
+    assert.strictEqual(loadedFunction, null);
+  });
+
+  it('fails to load a function that does not exist', async () => {
     const loadedFunction = await loader.getUserFunction(
       process.cwd() + '/test/data/with_main',
       'functionDoesNotExist',


### PR DESCRIPTION
The existing module resolution logic has two logic errors which create a confusing experience when the customer's module isn't found:

 1. `null` is never returned even when the module is not found, this means function framework doesn't early return with an exception when it should if the function does not exist.
 2. The error message will accurately reflect the original path instead of including `/function.js` prefix which gets incorporated as a side effect of the implementation today.

This change simplifies the function and cleans up these errors. 