### PR TITLE
chore: Ignore typescript dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,5 @@
     "experimental/**"
   ],
   "pinVersions": false,
-  // Cannot update typescript after version 5.0.4 because of https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-1.html#breaking-changes
   "ignoreDeps": ["typescript"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,5 +16,7 @@
     "docs/**",
     "experimental/**"
   ],
-  "pinVersions": false
+  "pinVersions": false,
+  // Cannot update typescript after version 5.0.4 because of https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-1.html#breaking-changes
+  "ignoreDeps": ["typescript"]
 }


### PR DESCRIPTION
[Typescript 5.1 requires node >= 14.17](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-1.html#breaking-changes). Functions framework needs to support older versions (10, 12) hence the transpiler will stop working for older node runtimes.