### PR TITLE
fix: framework fails to shutdown gracefully when exit code is a string

### DIFF
--- a/src/invoker.ts
+++ b/src/invoker.ts
@@ -100,7 +100,10 @@ export class ErrorHandler {
       sendCrashResponse({err, res: latestRes, callback: killInstance});
     });
 
-    process.on('exit', code => {
+    process.on('exit', (code: number | string) => {
+      if (typeof code === 'string') {
+        code = parseInt(code);
+      }
       sendCrashResponse({
         err: new Error(`Process exited with code ${code}`),
         res: latestRes,


### PR DESCRIPTION
Despite the Node.js docs indicating that the [exit code should always be a number](https://nodejs.org/docs/latest-v10.x/api/process.html#process_event_exit) it seems this is unchecked and, in fact, `process.exit` may be called with a string value.

Verified experimentally:
```
// test.js
const process = require("process");

process.on('exit', function(code) {
   console.log(typeof code);
   console.log(code);
});

process.exit('abc');
// output
string
abc
```

Some Cloud Function users report errors on shutdown when either their code or a dependency calls process.exit with a string value. To account for this the exit code check is updated to use string comparison to account for the possibility of a string exit code.