### PR TITLE
feat: add execution id support

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ ignored.
 | `--target`         | `FUNCTION_TARGET`         | The name of the exported function to be invoked in response to requests. Default: `function`                                                                                                                     |
 | `--signature-type` | `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function. Default: `http`; accepted values: `http` or `event` or `cloudevent` |
 | `--source`         | `FUNCTION_SOURCE`         | The path to the directory of your function. Default: `cwd` (the current working directory)                                                                                                                       |
+| `--enable-execution-id`         | `ENABLE_EXECUTION_ID`         | Whether or not to enable execution id support. When enable, exeuction id will be added to log.                                                                                                                     |
 
 You can set command-line flags in your `package.json` via the `start` script.
 For example:

--- a/src/execution_context.ts
+++ b/src/execution_context.ts
@@ -1,0 +1,55 @@
+import {AsyncLocalStorage} from 'node:async_hooks';
+import {Request, Response, NextFunction} from 'express';
+
+export const asyncLocalStorage = new AsyncLocalStorage();
+
+export interface ExeuctionContext {
+  'logging.googleapis.com/labels': {
+    executionId: string;
+  };
+  'logging.googleapis.com/trace'?: string;
+  'logging.googleapis.com/spanId'?: string;
+}
+
+export const executionContextMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  let executionId = req.header('function-execution-id');
+  if (!executionId || executionId.length !== 12) {
+    executionId = generateExecutionId();
+  }
+
+  let traceId, spanId, options;
+  const cloudTraceContext = req.header('X-Cloud-Trace-Context');
+  const regex = /^(?<traceId>\w+)\/(?<spanId>\d+);o=(?<options>.+)$/;
+  if (cloudTraceContext) {
+    const match = cloudTraceContext.match(regex);
+    if (match?.groups) {
+      ({traceId, spanId, options} = match.groups);
+    }
+  }
+
+  const executionContext = <ExeuctionContext>{
+    'logging.googleapis.com/labels': {
+      executionId: executionId,
+    },
+    'logging.googleapis.com/trace': traceId,
+    'logging.googleapis.com/spanId': spanId,
+  };
+
+  asyncLocalStorage.run(executionContext, () => {
+    next();
+  });
+};
+
+export function getCurrentContext() {
+  return asyncLocalStorage.getStore();
+}
+
+function generateExecutionId() {
+  const timestampPart = Date.now().toString(36).slice(-6);
+  const randomPart = Math.random().toString(36).slice(-6);
+  return timestampPart + randomPart;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import {getUserFunction} from './loader';
 import {ErrorHandler} from './invoker';
 import {getServer} from './server';
 import {parseOptions, helpText, OptionsError} from './options';
+import {loggingHandlerAddExecutionContext} from './logger';
 
 /**
  * Main entrypoint for the functions framework that loads the user's function
@@ -27,6 +28,8 @@ import {parseOptions, helpText, OptionsError} from './options';
  */
 export const main = async () => {
   try {
+    loggingHandlerAddExecutionContext();
+
     const options = parseOptions();
 
     if (options.printHelp) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,14 +28,17 @@ import {loggingHandlerAddExecutionContext} from './logger';
  */
 export const main = async () => {
   try {
-    loggingHandlerAddExecutionContext();
-
     const options = parseOptions();
 
     if (options.printHelp) {
       console.error(helpText);
       return;
     }
+
+    if (options.enableExecutionId) {
+      loggingHandlerAddExecutionContext();
+    }
+
     const loadedFunction = await getUserFunction(
       options.sourceLocation,
       options.target,

--- a/src/options.ts
+++ b/src/options.ts
@@ -47,6 +47,10 @@ export interface FrameworkOptions {
    * Whether or not the --help CLI flag was provided.
    */
   printHelp: boolean;
+  /**
+   * Whether or not to enable execution id support.
+   */
+  enableExecutionId: boolean;
 }
 
 /**
@@ -107,6 +111,17 @@ const SignatureOption = new ConfigurableOption(
     );
   }
 );
+const EnableExecutionIdOption = new ConfigurableOption(
+  'enable-execution-id',
+  'ENABLE_EXECUTION_ID',
+  false,
+  x => {
+    return (
+      (typeof x === 'boolean' && x) ||
+      (typeof x === 'string' && x.toLowerCase() === 'true')
+    );
+  }
+);
 
 export const helpText = `Example usage:
   functions-framework --target=helloWorld --port=8080
@@ -131,6 +146,7 @@ export const parseOptions = (
       SignatureOption.cliOption,
       SourceLocationOption.cliOption,
     ],
+    boolean: [EnableExecutionIdOption.cliOption,],
   });
   return {
     port: PortOption.parse(argv, envVars),
@@ -138,5 +154,6 @@ export const parseOptions = (
     sourceLocation: SourceLocationOption.parse(argv, envVars),
     signatureType: SignatureOption.parse(argv, envVars),
     printHelp: cliArgs[2] === '-h' || cliArgs[2] === '--help',
+    enableExecutionId: EnableExecutionIdOption.parse(argv, envVars),
   };
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,7 @@ import {legacyPubSubEventMiddleware} from './pubsub_middleware';
 import {cloudEventToBackgroundEventMiddleware} from './middleware/cloud_event_to_background_event';
 import {backgroundEventToCloudEventMiddleware} from './middleware/background_event_to_cloud_event';
 import {wrapUserFunction} from './function_wrappers';
+import {executionContextMiddleware} from './execution_context';
 
 /**
  * Creates and configures an Express application and returns an HTTP server
@@ -109,6 +110,9 @@ export function getServer(
 
   // Disable Express eTag response header
   app.set('etag', false);
+
+  // Stores execution context to asyncLocalStorage.
+  app.use(executionContextMiddleware);
 
   if (
     functionSignatureType === 'event' ||

--- a/test/execution_context.ts
+++ b/test/execution_context.ts
@@ -1,0 +1,114 @@
+import {
+  executionContextMiddleware,
+  getCurrentContext,
+  ExeuctionContext,
+} from '../src/execution_context';
+import {Request, Response, NextFunction} from 'express';
+import * as assert from 'assert';
+
+describe('executionContextMiddleware', () => {
+  const createRequest = (
+    body: object | string,
+    headers?: {[key: string]: string}
+  ) =>
+    ({
+      body,
+      header: (h: string) => {
+        return headers === undefined ? '' : headers[h];
+      },
+    }) as Request;
+
+  const testSpanId = '123';
+  const testTrace = 'testtrace';
+  const cloudTraceContext = `${testTrace}/${testSpanId};o=1`;
+  const validExecutionId = 'xn1h9xdgv6zw';
+  function assertExecutionContext(exeuctionContext?: ExeuctionContext) {
+    assert(exeuctionContext);
+    assert.strictEqual(
+      (exeuctionContext as ExeuctionContext)['logging.googleapis.com/labels']
+        ?.executionId.length,
+      12
+    );
+    assert.strictEqual(
+      exeuctionContext['logging.googleapis.com/spanId'],
+      testSpanId
+    );
+    assert.strictEqual(
+      exeuctionContext['logging.googleapis.com/trace'],
+      testTrace
+    );
+  }
+
+  it('uses execution ID in header', () => {
+    const request = createRequest(
+      {},
+      {
+        'X-Cloud-Trace-Context': cloudTraceContext,
+        'function-execution-id': validExecutionId,
+      }
+    );
+    let exeuctionContext;
+    const next = () => {
+      exeuctionContext = getCurrentContext() as ExeuctionContext;
+    };
+
+    executionContextMiddleware(
+      request as Request,
+      {} as Response,
+      next as NextFunction
+    );
+    assert(exeuctionContext);
+    assert.deepEqual(exeuctionContext['logging.googleapis.com/labels'], {
+      executionId: validExecutionId,
+    });
+    assert.strictEqual(
+      exeuctionContext['logging.googleapis.com/spanId'],
+      testSpanId
+    );
+    assert.strictEqual(
+      exeuctionContext['logging.googleapis.com/trace'],
+      testTrace
+    );
+  });
+
+  it('generates execution ID if not in header', () => {
+    const request = createRequest(
+      {},
+      {'X-Cloud-Trace-Context': cloudTraceContext}
+    );
+    let exeuctionContext;
+    const next = () => {
+      exeuctionContext = getCurrentContext() as ExeuctionContext;
+    };
+
+    executionContextMiddleware(
+      request as Request,
+      {} as Response,
+      next as NextFunction
+    );
+
+    assertExecutionContext(exeuctionContext);
+  });
+
+  it('generates execution ID if header is malformed', () => {
+    const request = createRequest(
+      {},
+      {
+        'X-Cloud-Trace-Context': cloudTraceContext,
+        'function-execution-id': 'abcde',
+      }
+    );
+    let exeuctionContext;
+    const next = () => {
+      exeuctionContext = getCurrentContext() as ExeuctionContext;
+    };
+
+    executionContextMiddleware(
+      request as Request,
+      {} as Response,
+      next as NextFunction
+    );
+
+    assertExecutionContext(exeuctionContext);
+  });
+});

--- a/test/logger.ts
+++ b/test/logger.ts
@@ -1,0 +1,132 @@
+import * as sinon from 'sinon';
+import * as assert from 'assert';
+import {splitArgs, getModifiedData} from '../src/logger';
+import * as executionContext from '../src/execution_context';
+
+describe('splitArgs', () => {
+  const expectedCallback = () => {};
+  const expectedEncoding = 'utf-8';
+
+  it('empty', () => {
+    const {encoding, cb} = splitArgs([]);
+    assert.equal(encoding, undefined);
+    assert.equal(cb, undefined);
+  });
+
+  it('callback', () => {
+    const {encoding, cb} = splitArgs([expectedCallback]);
+    assert.equal(encoding, undefined);
+    assert.equal(cb, expectedCallback);
+  });
+
+  it('encoding', () => {
+    const {encoding, cb} = splitArgs([expectedEncoding]);
+    assert.equal(encoding, expectedEncoding);
+    assert.equal(cb, undefined);
+  });
+
+  it('encoding and callback', () => {
+    const {encoding, cb} = splitArgs([expectedEncoding, expectedCallback]);
+    assert.equal(encoding, expectedEncoding);
+    assert.equal(cb, expectedCallback);
+  });
+
+  it('invalid args', () => {
+    const {encoding, cb} = splitArgs(['error-encoding', expectedCallback]);
+    assert.equal(encoding, undefined);
+    assert.equal(cb, undefined);
+  });
+});
+
+describe('getModifiedData', () => {
+  const sampleText = 'abc';
+  const sampleJSON = JSON.stringify({
+    text: 'default text.',
+    component: 'arbitrary-property',
+  });
+  const expectedExecutionContext = {
+    'logging.googleapis.com/labels': {
+      executionId: 'testExecutionId',
+    },
+    'logging.googleapis.com/trace': 'testTraceId',
+    'logging.googleapis.com/spanId': 'testSpanId',
+  };
+  const expectedTextOutput =
+    JSON.stringify({
+      ...expectedExecutionContext,
+      message: sampleText,
+    }) + '\n';
+  const expectedJSONOutput =
+    JSON.stringify({
+      ...expectedExecutionContext,
+      ...JSON.parse(sampleJSON),
+    }) + '\n';
+
+  function utf8ToHex(data: string) {
+    return Buffer.from(data, 'utf-8').toString('hex');
+  }
+
+  let getCurrentContextStub: sinon.SinonStub;
+  beforeEach(() => {
+    getCurrentContextStub = sinon.stub(executionContext, 'getCurrentContext');
+    getCurrentContextStub.returns(expectedExecutionContext);
+  });
+
+  afterEach(() => {
+    getCurrentContextStub.restore();
+  });
+
+  it('simple text', () => {
+    const modifiedData = getModifiedData(sampleText);
+    assert.equal(modifiedData, expectedTextOutput);
+  });
+
+  it('json', () => {
+    const modifiedData = getModifiedData(sampleJSON);
+    assert.equal(modifiedData, expectedJSONOutput);
+  });
+
+  it('uint8array', () => {
+    const modifiedData = getModifiedData(Buffer.from(sampleText));
+    assert.equal(modifiedData, expectedTextOutput);
+  });
+
+  it('simple text with encoding', () => {
+    const modifiedData = getModifiedData(utf8ToHex(sampleText), 'hex');
+    assert.equal(modifiedData, expectedTextOutput);
+  });
+
+  it('json with encoding', () => {
+    const modifiedData = getModifiedData(utf8ToHex(sampleJSON), 'hex');
+    assert.equal(modifiedData, expectedJSONOutput);
+  });
+
+  it('uint8Array with encoding', () => {
+    // Encoding will be ignored when the first parameter is Uint8Array.
+    // This behavious is the same as process.stdout[/stderr].write.
+    const modifiedData = getModifiedData(Buffer.from(sampleText), 'hex');
+    assert.equal(modifiedData, expectedTextOutput);
+  });
+
+  it('simple text with error', () => {
+    const modifiedData = getModifiedData(sampleText, undefined, true);
+    const expectedOutput =
+      JSON.stringify({
+        ...expectedExecutionContext,
+        message: sampleText,
+        severity: 'ERROR',
+      }) + '\n';
+    assert.equal(modifiedData, expectedOutput);
+  });
+
+  it('json with error', () => {
+    const modifiedData = getModifiedData(sampleJSON, undefined, true);
+    const expectedOutput =
+      JSON.stringify({
+        ...expectedExecutionContext,
+        ...JSON.parse(sampleJSON),
+        severity: 'ERROR',
+      }) + '\n';
+    assert.equal(modifiedData, expectedOutput);
+  });
+});

--- a/test/options.ts
+++ b/test/options.ts
@@ -51,6 +51,7 @@ describe('parseOptions', () => {
         sourceLocation: resolve(''),
         signatureType: 'http',
         printHelp: false,
+        enableExecutionId: false
       },
     },
     {
@@ -64,6 +65,7 @@ describe('parseOptions', () => {
         '--signature-type',
         'cloudevent',
         '--source=/source',
+        '--enable-execution-id'
       ],
       envVars: {},
       expectedOptions: {
@@ -72,6 +74,7 @@ describe('parseOptions', () => {
         sourceLocation: resolve('/source'),
         signatureType: 'cloudevent',
         printHelp: false,
+        enableExecutionId: true
       },
     },
     {
@@ -82,6 +85,7 @@ describe('parseOptions', () => {
         FUNCTION_TARGET: 'helloWorld',
         FUNCTION_SIGNATURE_TYPE: 'cloudevent',
         FUNCTION_SOURCE: '/source',
+        ENABLE_EXECUTION_ID: 'True'
       },
       expectedOptions: {
         port: '1234',
@@ -89,6 +93,7 @@ describe('parseOptions', () => {
         sourceLocation: resolve('/source'),
         signatureType: 'cloudevent',
         printHelp: false,
+        enableExecutionId: true
       },
     },
     {
@@ -102,12 +107,14 @@ describe('parseOptions', () => {
         '--signature-type',
         'cloudevent',
         '--source=/source',
+        '--enable-execution-id'
       ],
       envVars: {
         PORT: '4567',
         FUNCTION_TARGET: 'fooBar',
         FUNCTION_SIGNATURE_TYPE: 'event',
         FUNCTION_SOURCE: '/somewhere/else',
+        ENABLE_EXECUTION_ID: 'false'
       },
       expectedOptions: {
         port: '1234',
@@ -115,6 +122,7 @@ describe('parseOptions', () => {
         sourceLocation: resolve('/source'),
         signatureType: 'cloudevent',
         printHelp: false,
+        enableExecutionId: true
       },
     },
   ];


### PR DESCRIPTION
Add execution id support.

When enabled with `--enable-execution-id` or set `ENABLE_EXECUTION_ID=True` in environment variables, execution id will be added to log.