### PR TITLE
fix: parse structured logs, and handle ANSI escape codes in logs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-    "extends": "./node_modules/gts"
+    "extends": "./node_modules/gts",
+    "rules": {
+        "no-control-regex": 0
+    }
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -137,12 +137,14 @@ export function getModifiedData(
   };
   if (isJSON) {
     dataWithContext = getJSONWithContext(processedData, currentContext);
-    if (!(SEVERITY in dataWithContext)) {
-      dataWithContext[SEVERITY] = stderr ? 'ERROR' : 'INFO';
+    if (stderr && !(SEVERITY in dataWithContext)) {
+      dataWithContext[SEVERITY] = 'ERROR';
     }
   } else {
     dataWithContext = getTextWithContext(processedData, currentContext);
-    dataWithContext[SEVERITY] = stderr ? 'ERROR' : 'INFO';
+    if (stderr) {
+      dataWithContext[SEVERITY] = 'ERROR';
+    }
   }
 
   return JSON.stringify(dataWithContext) + '\n';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -188,8 +188,8 @@ function processData(data: Uint8Array | string, encoding?: BufferEncoding) {
     return {isJSON: false, processedData: data};
   }
 
-  // strip any leading ANSI terminal codes from the decoded data
-  // before trying to parse it as json
+  // strip any leading ANSI color codes from the decoded data
+  // to parse colored JSON objects correctly
   decodedData = decodedData.replace(/\x1b[[(?);]{0,2}(;?\d)*./g, '');
   try {
     return {isJSON: true, processedData: JSON.parse(decodedData)};

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -188,7 +188,7 @@ function processData(data: Uint8Array | string, encoding?: BufferEncoding) {
     return {isJSON: false, processedData: data};
   }
 
-  // strip any leading ANSI terminal codes from the start of the decoded data
+  // strip any leading ANSI terminal codes from the decoded data
   // before trying to parse it as json
   decodedData = decodedData.replace(/\x1b[[(?);]{0,2}(;?\d)*./g, '');
   try {

--- a/test/logger.ts
+++ b/test/logger.ts
@@ -148,4 +148,42 @@ describe('getModifiedData', () => {
       ) + '\n';
     assert.equal(modifiedData, expectedOutput);
   });
+
+  it('parses firebase log severity', () => {
+    const modifiedData = <string>(
+      getModifiedData('testing info log level', undefined, false)
+    );
+    assert.equal('INFO', JSON.parse(modifiedData)['severity']);
+    assert.equal('testing info log level', JSON.parse(modifiedData)['message']);
+  });
+
+  it('parses firebase warning severity', () => {
+    const modifiedData = <string>(
+      getModifiedData(
+        '\u001b[33m{"severity":"WARNING","message":"testing warning log level"}\u001b[39m\n',
+        undefined,
+        true
+      )
+    );
+    assert.equal('WARNING', JSON.parse(modifiedData)['severity']);
+    assert.equal(
+      'testing warning log level',
+      JSON.parse(modifiedData)['message']
+    );
+  });
+
+  it('parses firebase error severity', () => {
+    const modifiedData = <string>(
+      getModifiedData(
+        '\u001b[31m{"severity":"ERROR","message":"testing error log level"}\u001b[39m\n',
+        undefined,
+        true
+      )
+    );
+    assert.equal('ERROR', JSON.parse(modifiedData)['severity']);
+    assert.equal(
+      'testing error log level',
+      JSON.parse(modifiedData)['message']
+    );
+  });
 });

--- a/test/logger.ts
+++ b/test/logger.ts
@@ -149,15 +149,7 @@ describe('getModifiedData', () => {
     assert.equal(modifiedData, expectedOutput);
   });
 
-  it('parses firebase log severity', () => {
-    const modifiedData = <string>(
-      getModifiedData('testing info log level', undefined, false)
-    );
-    assert.equal('INFO', JSON.parse(modifiedData)['severity']);
-    assert.equal('testing info log level', JSON.parse(modifiedData)['message']);
-  });
-
-  it('parses firebase warning severity', () => {
+  it('parses firebase warning severity and message', () => {
     const modifiedData = <string>(
       getModifiedData(
         '\u001b[33m{"severity":"WARNING","message":"testing warning log level"}\u001b[39m\n',
@@ -172,7 +164,7 @@ describe('getModifiedData', () => {
     );
   });
 
-  it('parses firebase error severity', () => {
+  it('parses firebase error severity and message', () => {
     const modifiedData = <string>(
       getModifiedData(
         '\u001b[31m{"severity":"ERROR","message":"testing error log level"}\u001b[39m\n',


### PR DESCRIPTION
`firebase-functions/logger` writes structured logs to stdout and stderr by default, and makes these pretty with ANSI color codes.

When functions-framework intercepts these messages to assign execution IDs, it handles them incorrectly in two ways.

First, when the log emitted on stdout or stderr is already a structured log, we override (ignore) the severity set by the logger.  This commit avoids changing severity if it's already set.

Second, when parsing the message and attempting to determine if it's already a json object/structured log, it doesn't handle ANSI escape codes (https://en.wikipedia.org/wiki/ANSI_escape_code) used to control color, so parsing these will fail.  This means that severity handling falls back to just looking at whether the message came from stdout or stderr, so debug-level and warn-level logs aren't handled correctly.  This commit strips all ANSI escape codes that control terminal color.  This is a minor bummer because it's a whole lot less pretty, but color-coding and smarter color coding generally seems less important than correct log-level handling.

Fixes #617.