### PR TITLE
fix: Don't set severity level for text log.

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -142,9 +142,6 @@ export function getModifiedData(
     }
   } else {
     dataWithContext = getTextWithContext(processedData, currentContext);
-    if (stderr) {
-      dataWithContext[SEVERITY] = 'ERROR';
-    }
   }
 
   return JSON.stringify(dataWithContext) + '\n';

--- a/test/logger.ts
+++ b/test/logger.ts
@@ -135,7 +135,7 @@ describe('getModifiedData', () => {
     const modifiedData = getModifiedData(sampleText, undefined, true);
     const expectedOutput =
       JSON.stringify(
-        Object.assign(JSON.parse(expectedTextOutput), {severity: 'ERROR'})
+        Object.assign(JSON.parse(expectedTextOutput))
       ) + '\n';
     assert.equal(modifiedData, expectedOutput);
   });

--- a/test/logger.ts
+++ b/test/logger.ts
@@ -134,9 +134,7 @@ describe('getModifiedData', () => {
   it('simple text with error', () => {
     const modifiedData = getModifiedData(sampleText, undefined, true);
     const expectedOutput =
-      JSON.stringify(
-        Object.assign(JSON.parse(expectedTextOutput))
-      ) + '\n';
+      JSON.stringify(Object.assign(JSON.parse(expectedTextOutput))) + '\n';
     assert.equal(modifiedData, expectedOutput);
   });
 


### PR DESCRIPTION
For text log, we don't set severity level so that it will fall back to default behavior, i.e. severity: "DEFAULT".