### PR TITLE
fix: Fix typings for functions.cloudEvent to include callback.

### DIFF
--- a/src/function_registry.ts
+++ b/src/function_registry.ts
@@ -18,6 +18,7 @@ import {
   HandlerFunction,
   TypedFunction,
   JsonInvocationFormat,
+  CloudEventFunctionWithCallback,
 } from './functions';
 import {SignatureType} from './types';
 
@@ -96,7 +97,7 @@ export const http = (functionName: string, handler: HttpFunction): void => {
  */
 export const cloudEvent = <T = unknown>(
   functionName: string,
-  handler: CloudEventFunction<T>
+  handler: CloudEventFunction<T> | CloudEventFunctionWithCallback<T>
 ): void => {
   register(functionName, 'cloudevent', handler);
 };

--- a/test/integration/cloud_event.ts
+++ b/test/integration/cloud_event.ts
@@ -41,9 +41,12 @@ describe('CloudEvent Function', () => {
 
   let receivedCloudEvent: functions.CloudEvent<unknown> | null;
   before(() => {
-    functions.cloudEvent('testCloudEventFunction', ce => {
-      receivedCloudEvent = ce;
-    });
+    functions.cloudEvent(
+      'testCloudEventFunction',
+      (ce: functions.CloudEvent<unknown>) => {
+        receivedCloudEvent = ce;
+      }
+    );
   });
 
   beforeEach(() => {
@@ -288,11 +291,14 @@ describe('CloudEvent Function', () => {
     const testPayload = 'a test string';
 
     // register a strongly typed CloudEvent function
-    functions.cloudEvent<string>('testTypedCloudEvent', ce => {
-      assert.deepStrictEqual(ce.data, testPayload);
-      // use a property that proves this is actually typed as a string
-      assert.deepStrictEqual(ce.data.length, testPayload.length);
-    });
+    functions.cloudEvent<string>(
+      'testTypedCloudEvent',
+      (ce: functions.CloudEvent<string>) => {
+        assert.deepStrictEqual(ce.data, testPayload);
+        // use a property that proves this is actually typed as a string
+        assert.deepStrictEqual(ce.data.length, testPayload.length);
+      }
+    );
 
     // invoke the function with a CloudEvent with a string payload
     const server = getTestServer('testTypedCloudEvent');
@@ -304,6 +310,32 @@ describe('CloudEvent Function', () => {
       })
       .expect(204);
   });
+
+  it('allows customers to use a handler with callbacks for failure', async () => {
+    const testPayload = 'a test string';
+
+    // register a strongly typed CloudEvent function
+    functions.cloudEvent<string>(
+      'testTypedCloudEvent',
+      (ce: functions.CloudEvent<string>, callback) => {
+        assert.deepStrictEqual(ce.data, testPayload);
+        // use a property that proves this is actually typed as a string
+        assert.deepStrictEqual(ce.data.length, testPayload.length);
+        callback();
+      }
+    );
+
+    // invoke the function with a CloudEvent with a string payload
+    const server = getTestServer('testTypedCloudEvent');
+    await supertest(server)
+      .post('/')
+      .send({
+        ...TEST_CLOUD_EVENT,
+        data: testPayload,
+      })
+      .expect(204);
+  });
+
 
   it('returns a 500 if the function throws an exception', async () => {
     functions.cloudEvent('testTypedCloudEvent', () => {


### PR DESCRIPTION
This commit adds the typing to specific a CloudEventFunctionWithCallback as the handler for functions.cloudEvent() function.

Fixes #633 