### PR TITLE
chore: add missing allowed-endpoints to workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            api.github.com:443
             github.com:443
             registry.npmjs.org:443
             wombat-dressing-room.appspot.com:443

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,6 +39,7 @@ jobs:
             sigstore-tuf-root.storage.googleapis.com:443
             *.sigstore.dev:443
             api.securityscorecards.dev:443
+            www.bestpractices.dev:443
 
       - name: 'Checkout code'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7


### PR DESCRIPTION
the hardener is currently blocking traffic to these endpoints but they are required for the pipeline