### PR TITLE
chore: allowlist more endpoints

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             github.com:443
+            objects.githubusercontent.com:443
             registry.npmjs.org:443
             wombat-dressing-room.appspot.com:443
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,6 +33,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             api.osv.dev:443
+            api.scorecard.dev:443
             bestpractices.coreinfrastructure.org:443
             github.com:443
             oss-fuzz-build-logs.storage.googleapis.com:443


### PR DESCRIPTION
- objects.githubusercontent.com:443 is required for the publish workflow
- api.scorecard.dev:443 is required for the openssf scorecard