### PR TITLE
fix: do not call render in the errorHandler

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -99,8 +99,7 @@ export const errorHandler = (
   next: express.NextFunction // eslint-disable-line @typescript-eslint/no-unused-vars
 ) => {
   interceptStderrWrite();
-  res.status(500);
-  res.render('error', {error: err});
+  sendCrashResponse({err, res});
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This should fix the "Error: No default engine was specified and no extension was provided" issues we have been seeing.

fixes #657, #652