### PR TITLE
introduce a new option for configuring ignored routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ ignored.
 | `--signature-type` | `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function. Default: `http`; accepted values: `http` or `event` or `cloudevent` |
 | `--source`         | `FUNCTION_SOURCE`         | The path to the directory of your function. Default: `cwd` (the current working directory)                                                                                                                       |
 | `--log-execution-id`| `LOG_EXECUTION_ID`        | Enables execution IDs in logs, either `true` or `false`. When not specified, default to disable. Requires Node.js 13.0.0 or later.                                                                                |
+| `--ignored-routes`| `IGNORED_ROUTES`        | A route expression for requests that should not be routed the function. An empty 404 response will be returned. This is set to `/favicon.ico|/robots.txt` by default for `http` functions.                                                     |
 
 You can set command-line flags in your `package.json` via the `start` script.
 For example:

--- a/src/options.ts
+++ b/src/options.ts
@@ -56,6 +56,10 @@ export interface FrameworkOptions {
    * The request timeout.
    */
   timeoutMilliseconds: number;
+  /**
+   * Routes that should return a 404 without invoking the function.
+   */
+  ignoredRoutes: string | null;
 }
 
 /**
@@ -86,7 +90,7 @@ class ConfigurableOption<T> {
 
   parse(cliArgs: minimist.ParsedArgs, envVars: NodeJS.ProcessEnv): T {
     return this.validator(
-      cliArgs[this.cliOption] || envVars[this.envVar] || this.defaultValue
+      cliArgs[this.cliOption] ?? envVars[this.envVar] ?? this.defaultValue
     );
   }
 }
@@ -129,6 +133,11 @@ const TimeoutOption = new ConfigurableOption(
     }
     return x * 1000;
   }
+);
+const IgnoredRoutesOption = new ConfigurableOption<string | null>(
+  'ignored-routes',
+  'IGNORED_ROUTES',
+  null // null by default so we can detect if it is explicitly set to ""
 );
 
 export const requiredNodeJsVersionForLogExecutionID = '13.0.0';
@@ -181,6 +190,7 @@ export const parseOptions = (
       SignatureOption.cliOption,
       SourceLocationOption.cliOption,
       TimeoutOption.cliOption,
+      IgnoredRoutesOption.cliOption,
     ],
   });
   return {
@@ -191,5 +201,6 @@ export const parseOptions = (
     timeoutMilliseconds: TimeoutOption.parse(argv, envVars),
     printHelp: cliArgs[2] === '-h' || cliArgs[2] === '--help',
     enableExecutionId: ExecutionIdOption.parse(argv, envVars),
+    ignoredRoutes: IgnoredRoutesOption.parse(argv, envVars),
   };
 };

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -56,5 +56,6 @@ export const getTestServer = (functionName: string): Server => {
     target: '',
     sourceLocation: '',
     printHelp: false,
+    ignoredRoutes: null,
   });
 };

--- a/test/integration/legacy_event.ts
+++ b/test/integration/legacy_event.ts
@@ -40,6 +40,7 @@ const testOptions = {
   target: '',
   sourceLocation: '',
   printHelp: false,
+  ignoredRoutes: null,
 };
 
 describe('Event Function', () => {

--- a/test/options.ts
+++ b/test/options.ts
@@ -60,6 +60,7 @@ describe('parseOptions', () => {
         printHelp: false,
         enableExecutionId: false,
         timeoutMilliseconds: 0,
+        ignoredRoutes: null,
       },
     },
     {
@@ -75,6 +76,7 @@ describe('parseOptions', () => {
         '--source=/source',
         '--timeout',
         '6',
+        '--ignored-routes=banana',
       ],
       envVars: {},
       expectedOptions: {
@@ -85,6 +87,7 @@ describe('parseOptions', () => {
         printHelp: false,
         enableExecutionId: false,
         timeoutMilliseconds: 6000,
+        ignoredRoutes: 'banana',
       },
     },
     {
@@ -96,6 +99,7 @@ describe('parseOptions', () => {
         FUNCTION_SIGNATURE_TYPE: 'cloudevent',
         FUNCTION_SOURCE: '/source',
         CLOUD_RUN_TIMEOUT_SECONDS: '2',
+        IGNORED_ROUTES: '',
       },
       expectedOptions: {
         port: '1234',
@@ -105,6 +109,7 @@ describe('parseOptions', () => {
         printHelp: false,
         enableExecutionId: false,
         timeoutMilliseconds: 2000,
+        ignoredRoutes: '',
       },
     },
     {
@@ -119,6 +124,7 @@ describe('parseOptions', () => {
         'cloudevent',
         '--source=/source',
         '--timeout=3',
+        '--ignored-routes=avocado',
       ],
       envVars: {
         PORT: '4567',
@@ -126,6 +132,7 @@ describe('parseOptions', () => {
         FUNCTION_SIGNATURE_TYPE: 'event',
         FUNCTION_SOURCE: '/somewhere/else',
         CLOUD_RUN_TIMEOUT_SECONDS: '5',
+        IGNORED_ROUTES: 'banana',
       },
       expectedOptions: {
         port: '1234',
@@ -135,6 +142,7 @@ describe('parseOptions', () => {
         printHelp: false,
         enableExecutionId: false,
         timeoutMilliseconds: 3000,
+        ignoredRoutes: 'avocado',
       },
     },
   ];


### PR DESCRIPTION
Can be set to a single path or regular expression for URL paths that should get an empty 404 response without invoking the user function. Historically we have always filtered out `/robots.txt|/favicon.ico` but have received feedback from customers who would like to overrider this behavior. 