### PR TITLE
chore: nodejs versions in github workflows

### DIFF
--- a/.github/workflows/buildpack-integration-test.yml
+++ b/.github/workflows/buildpack-integration-test.yml
@@ -14,46 +14,6 @@ on:
 permissions: read-all
 
 jobs:
-  nodejs10:
-    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@main
-    with:
-      http-builder-source: 'test/conformance'
-      http-builder-target: 'writeHttpDeclarative'
-      cloudevent-builder-source: 'test/conformance'
-      cloudevent-builder-target: 'writeCloudEventDeclarative'
-      prerun: 'test/conformance/prerun.sh'
-      builder-runtime: 'nodejs10'
-      builder-runtime-version: '10'
-  nodejs12:
-    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@main
-    with:
-      http-builder-source: 'test/conformance'
-      http-builder-target: 'writeHttpDeclarative'
-      cloudevent-builder-source: 'test/conformance'
-      cloudevent-builder-target: 'writeCloudEventDeclarative'
-      prerun: 'test/conformance/prerun.sh'
-      builder-runtime: 'nodejs12'
-      builder-runtime-version: '12'
-  nodejs14:
-    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@main
-    with:
-      http-builder-source: 'test/conformance'
-      http-builder-target: 'writeHttpDeclarative'
-      cloudevent-builder-source: 'test/conformance'
-      cloudevent-builder-target: 'writeCloudEventDeclarative'
-      prerun: 'test/conformance/prerun.sh'
-      builder-runtime: 'nodejs14'
-      builder-runtime-version: '14'
-  nodejs16:
-    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@main
-    with:
-      http-builder-source: 'test/conformance'
-      http-builder-target: 'writeHttpDeclarative'
-      cloudevent-builder-source: 'test/conformance'
-      cloudevent-builder-target: 'writeCloudEventDeclarative'
-      prerun: 'test/conformance/prerun.sh'
-      builder-runtime: 'nodejs16'
-      builder-runtime-version: '16'
   nodejs18:
     uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@main
     with:
@@ -64,6 +24,7 @@ jobs:
       prerun: 'test/conformance/prerun.sh'
       builder-runtime: 'nodejs18'
       builder-runtime-version: '18'
+      builder-url: 'us-docker.pkg.dev/serverless-runtimes/google-22-full/builder/nodejs:latest'
   nodejs20:
     uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@main
     with:
@@ -74,3 +35,15 @@ jobs:
       prerun: 'test/conformance/prerun.sh'
       builder-runtime: 'nodejs20'
       builder-runtime-version: '20'
+      builder-url: 'us-docker.pkg.dev/serverless-runtimes/google-22-full/builder/nodejs:latest'
+  nodejs22:
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@main
+    with:
+      http-builder-source: 'test/conformance'
+      http-builder-target: 'writeHttpDeclarative'
+      cloudevent-builder-source: 'test/conformance'
+      cloudevent-builder-target: 'writeCloudEventDeclarative'
+      prerun: 'test/conformance/prerun.sh'
+      builder-runtime: 'nodejs22'
+      builder-runtime-version: '22'
+      builder-url: 'us-docker.pkg.dev/serverless-runtimes/google-22-full/builder/nodejs:latest'

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10, 12, 14, 16, 18, 20]
+        node-version: [18, 20, 22]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
-          node-version: '14'
+          node-version: '20'
       - name: Install dependencies
         run: npm ci
       - name: Build docs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,12 +25,12 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
-          node-version: '16.x'
+          node-version: '20.x'
       - run: npm install
       - run: npm run build
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
-          node-version: '16.x'
+          node-version: '20.x'
           registry-url: 'https://wombat-dressing-room.appspot.com'
       - id: publish
         env:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: [10, 12, 14, 16, 18, 20]
+        node-version: [18, 20, 22]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Updates all our Github workflows to drop versions 10, 12, 14, and 16 which are all deprecated. And then start including 22.