### PR TITLE
feat: propagate framework errors to user client application

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ ignored.
 | `--source`         | `FUNCTION_SOURCE`         | The path to the directory of your function. Default: `cwd` (the current working directory)                                                                                                                       |
 | `--log-execution-id`| `LOG_EXECUTION_ID`        | Enables execution IDs in logs, either `true` or `false`. When not specified, default to disable. Requires Node.js 13.0.0 or later.                                                                                |
 | `--ignored-routes`| `IGNORED_ROUTES`        | A route expression for requests that should not be routed the function. An empty 404 response will be returned. This is set to `/favicon.ico|/robots.txt` by default for `http` functions.                                                     |
+| `--propagate-framework-errors` | `PROPAGATE_FRAMEWORK_ERRORS` | Enables propagating framework errors to the client application error handler, either `true` or `false`. When not specified, default to disable.|
 
 You can set command-line flags in your `package.json` via the `start` script.
 For example:

--- a/src/middleware/propagate_error_to_client_error_handle.ts
+++ b/src/middleware/propagate_error_to_client_error_handle.ts
@@ -1,0 +1,101 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import {Request, Response, NextFunction, Express} from 'express';
+import {HandlerFunction} from '../functions';
+import {ILayer} from 'express-serve-static-core';
+
+/**
+ * Common properties that exists on Express object instances. Extracted by calling
+ * `Object.getOwnPropertyNames` on an express instance.
+ */
+const COMMON_EXPRESS_OBJECT_PROPERTIES = [
+  '_router',
+  'use',
+  'get',
+  'post',
+  'put',
+  'delete',
+];
+
+/** The number of parameters on an express error handler. */
+const EXPRESS_ERROR_HANDLE_PARAM_LENGTH = 4;
+
+/** A express app error handle. */
+interface ErrorHandle {
+  (err: Error, req: Request, res: Response, next: NextFunction): any;
+}
+
+/**
+ * Express middleware to propagate framework errors to the user function error handle.
+ * This enables users to handle framework errors that would otherwise be handled by the
+ * default Express error handle. If the user function doesn't have an error handle,
+ * it falls back to the default Express error handle.
+ * @param userFunction - User handler function
+ */
+export const createPropagateErrorToClientErrorHandleMiddleware = (
+  userFunction: HandlerFunction
+): ErrorHandle => {
+  const userFunctionErrorHandle =
+    getFirstUserFunctionErrorHandleMiddleware(userFunction);
+
+  return function (
+    err: Error,
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) {
+    // Propagate error to user function error handle.
+    if (userFunctionErrorHandle) {
+      return userFunctionErrorHandle(err, req, res, next);
+    }
+
+    // Propagate error to default Express error handle.
+    return next();
+  };
+};
+
+/**
+ * Returns the first user handler function defined error handle, if available.
+ * @param userFunction - User handler function
+ */
+const getFirstUserFunctionErrorHandleMiddleware = (
+  userFunction: HandlerFunction
+): ErrorHandle | null => {
+  if (!isExpressApp(userFunction)) {
+    return null;
+  }
+
+  const middlewares: ILayer[] = (userFunction as Express)._router.stack;
+  for (const middleware of middlewares) {
+    if (
+      middleware.handle &&
+      middleware.handle.length === EXPRESS_ERROR_HANDLE_PARAM_LENGTH
+    ) {
+      return middleware.handle as unknown as ErrorHandle;
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Returns if the user function contains common properties of an Express app.
+ * @param userFunction
+ */
+const isExpressApp = (userFunction: HandlerFunction): boolean => {
+  const userFunctionProperties = Object.getOwnPropertyNames(userFunction);
+  return COMMON_EXPRESS_OBJECT_PROPERTIES.every(prop =>
+    userFunctionProperties.includes(prop)
+  );
+};

--- a/src/middleware/propagate_error_to_client_error_handle.ts
+++ b/src/middleware/propagate_error_to_client_error_handle.ts
@@ -33,6 +33,7 @@ const EXPRESS_ERROR_HANDLE_PARAM_LENGTH = 4;
 
 /** A express app error handle. */
 interface ErrorHandle {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (err: Error, req: Request, res: Response, next: NextFunction): any;
 }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -15,7 +15,7 @@
 import * as minimist from 'minimist';
 import * as semver from 'semver';
 import {resolve} from 'path';
-import {SignatureType, isValidSignatureType} from './types';
+import {isValidSignatureType, SignatureType} from './types';
 
 /**
  * Error thrown when an invalid option is provided.
@@ -60,6 +60,10 @@ export interface FrameworkOptions {
    * Routes that should return a 404 without invoking the function.
    */
   ignoredRoutes: string | null;
+  /**
+   * Whether or not to propagate framework errors to the client.
+   */
+  propagateFrameworkErrors: boolean;
 }
 
 /**
@@ -167,6 +171,18 @@ const ExecutionIdOption = new ConfigurableOption(
   }
 );
 
+const PropagateFrameworkErrorsOption = new ConfigurableOption(
+  'propagate-framework-errors',
+  'PROPAGATE_FRAMEWORK_ERRORS',
+  false,
+  x => {
+    return (
+      (typeof x === 'boolean' && x) ||
+      (typeof x === 'string' && x.toLowerCase() === 'true')
+    );
+  }
+);
+
 export const helpText = `Example usage:
   functions-framework --target=helloWorld --port=8080
 Documentation:
@@ -191,6 +207,7 @@ export const parseOptions = (
       SourceLocationOption.cliOption,
       TimeoutOption.cliOption,
       IgnoredRoutesOption.cliOption,
+      PropagateFrameworkErrorsOption.cliOption,
     ],
   });
   return {
@@ -202,5 +219,9 @@ export const parseOptions = (
     printHelp: cliArgs[2] === '-h' || cliArgs[2] === '--help',
     enableExecutionId: ExecutionIdOption.parse(argv, envVars),
     ignoredRoutes: IgnoredRoutesOption.parse(argv, envVars),
+    propagateFrameworkErrors: PropagateFrameworkErrorsOption.parse(
+      argv,
+      envVars
+    ),
   };
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,6 +26,7 @@ import {wrapUserFunction} from './function_wrappers';
 import {asyncLocalStorageMiddleware} from './async_local_storage';
 import {executionContextMiddleware} from './execution_context';
 import {FrameworkOptions} from './options';
+import {createPropagateErrorToClientErrorHandleMiddleware} from './middleware/propagate_error_to_client_error_handle';
 
 /**
  * Creates and configures an Express application and returns an HTTP server
@@ -170,6 +171,12 @@ export function getServer(
     app.all('/*', requestHandler);
   } else {
     app.post('/*', requestHandler);
+  }
+
+  if (options.propagateFrameworkErrors) {
+    const errorHandleMiddleware =
+      createPropagateErrorToClientErrorHandleMiddleware(userFunction);
+    app.use(errorHandleMiddleware);
   }
 
   return http.createServer(app);

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -57,5 +57,6 @@ export const getTestServer = (functionName: string): Server => {
     sourceLocation: '',
     printHelp: false,
     ignoredRoutes: null,
+    propagateFrameworkErrors: false,
   });
 };

--- a/test/integration/legacy_event.ts
+++ b/test/integration/legacy_event.ts
@@ -41,6 +41,7 @@ const testOptions = {
   sourceLocation: '',
   printHelp: false,
   ignoredRoutes: null,
+  propagateFrameworkErrors: false,
 };
 
 describe('Event Function', () => {

--- a/test/middleware/propagate_error_to_client_error_handle.ts
+++ b/test/middleware/propagate_error_to_client_error_handle.ts
@@ -1,0 +1,68 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import {NextFunction} from 'express';
+import {Request, Response} from '../../src';
+import {createPropagateErrorToClientErrorHandleMiddleware} from '../../src/middleware/propagate_error_to_client_error_handle';
+import * as express from 'express';
+
+describe('propagateErrorToClientErrorHandleMiddleware', () => {
+  let request: Request;
+  let response: Response;
+  let next: NextFunction;
+  let errListener = () => {};
+  let error: Error;
+  beforeEach(() => {
+    error = Error('Something went wrong!');
+    request = {
+      setTimeout: sinon.spy(),
+      on: sinon.spy(),
+    } as unknown as Request;
+    response = {
+      on: sinon.spy(),
+    } as unknown as Response;
+    next = sinon.spy();
+    errListener = sinon.spy();
+  });
+
+  it('user express app with error handle calls user function app error handle', () => {
+    const app = express();
+    app.use(
+      (
+        _err: Error,
+        _req: Request,
+        _res: Response,
+        _next: NextFunction
+      ): any => {
+        errListener();
+      }
+    );
+
+    const middleware = createPropagateErrorToClientErrorHandleMiddleware(app);
+    middleware(error, request, response, next);
+
+    assert.strictEqual((errListener as sinon.SinonSpy).called, true);
+    assert.strictEqual((next as sinon.SinonSpy).called, false);
+  });
+
+  it('user express app without error handle calls default express error handle', () => {
+    const app = express();
+
+    const middleware = createPropagateErrorToClientErrorHandleMiddleware(app);
+    middleware(error, request, response, next);
+
+    assert.strictEqual((errListener as sinon.SinonSpy).called, false);
+    assert.strictEqual((next as sinon.SinonSpy).called, true);
+  });
+
+  it('non-express user app calls default express error handle', () => {
+    const app = (_req: Request, res: Response) => {
+      res.send('Hello, World!');
+    };
+
+    const middleware = createPropagateErrorToClientErrorHandleMiddleware(app);
+    middleware(error, request, response, next);
+
+    assert.strictEqual((errListener as sinon.SinonSpy).called, false);
+    assert.strictEqual((next as sinon.SinonSpy).called, true);
+  });
+});

--- a/test/middleware/propagate_error_to_client_error_handle.ts
+++ b/test/middleware/propagate_error_to_client_error_handle.ts
@@ -28,10 +28,15 @@ describe('propagateErrorToClientErrorHandleMiddleware', () => {
     const app = express();
     app.use(
       (
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         _err: Error,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         _req: Request,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         _res: Response,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         _next: NextFunction
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ): any => {
         errListener();
       }

--- a/test/options.ts
+++ b/test/options.ts
@@ -61,6 +61,7 @@ describe('parseOptions', () => {
         enableExecutionId: false,
         timeoutMilliseconds: 0,
         ignoredRoutes: null,
+        propagateFrameworkErrors: false,
       },
     },
     {
@@ -77,6 +78,7 @@ describe('parseOptions', () => {
         '--timeout',
         '6',
         '--ignored-routes=banana',
+        '--propagate-framework-errors=true',
       ],
       envVars: {},
       expectedOptions: {
@@ -88,6 +90,7 @@ describe('parseOptions', () => {
         enableExecutionId: false,
         timeoutMilliseconds: 6000,
         ignoredRoutes: 'banana',
+        propagateFrameworkErrors: true,
       },
     },
     {
@@ -100,6 +103,7 @@ describe('parseOptions', () => {
         FUNCTION_SOURCE: '/source',
         CLOUD_RUN_TIMEOUT_SECONDS: '2',
         IGNORED_ROUTES: '',
+        PROPAGATE_FRAMEWORK_ERRORS: 'true',
       },
       expectedOptions: {
         port: '1234',
@@ -110,6 +114,7 @@ describe('parseOptions', () => {
         enableExecutionId: false,
         timeoutMilliseconds: 2000,
         ignoredRoutes: '',
+        propagateFrameworkErrors: true,
       },
     },
     {
@@ -125,6 +130,7 @@ describe('parseOptions', () => {
         '--source=/source',
         '--timeout=3',
         '--ignored-routes=avocado',
+        '--propagate-framework-errors',
       ],
       envVars: {
         PORT: '4567',
@@ -133,6 +139,7 @@ describe('parseOptions', () => {
         FUNCTION_SOURCE: '/somewhere/else',
         CLOUD_RUN_TIMEOUT_SECONDS: '5',
         IGNORED_ROUTES: 'banana',
+        PROPAGATE_FRAMEWORK_ERRORS: 'false',
       },
       expectedOptions: {
         port: '1234',
@@ -143,6 +150,7 @@ describe('parseOptions', () => {
         enableExecutionId: false,
         timeoutMilliseconds: 3000,
         ignoredRoutes: 'avocado',
+        propagateFrameworkErrors: false,
       },
     },
   ];
@@ -235,5 +243,34 @@ describe('parseOptions', () => {
         parseOptions(testCase.cliOpts, testCase.envVars);
       });
     });
+  });
+
+  it('default disable propagate framework errors', () => {
+    const options = parseOptions(['bin/node', '/index.js'], {});
+    assert.strictEqual(options.propagateFrameworkErrors, false);
+  });
+
+  it('disable propagate framework errors by cli flag', () => {
+    const options = parseOptions(
+      ['bin/node', '/index.js', '--propagate-framework-errors=false'],
+      {}
+    );
+    assert.strictEqual(options.propagateFrameworkErrors, false);
+  });
+
+  it('enable propagate framework errors by cli flag', () => {
+    const options = parseOptions(
+      ['bin/node', '/index.js', '--propagate-framework-errors=true'],
+      {}
+    );
+    assert.strictEqual(options.propagateFrameworkErrors, true);
+  });
+
+  it('disable propagate framework errors by env var', () => {
+    const envVars = {
+      PROPAGATE_FRAMEWORK_ERRORS: 'False',
+    };
+    const options = parseOptions(cliOpts, envVars);
+    assert.strictEqual(options.propagateFrameworkErrors, false);
   });
 });


### PR DESCRIPTION
Currently, errors that happen in the framework express layer are passed to the default express error handler. The default error handler returns the error to the client with a stack trace if in non-prod enviornments. It would be useful for certain cases for the user to have context of what happened during a request instead of the user being bypassed entirely. Instead, if the user has an error handler middleware installed in their application, we should pass the framework error to the user's error handler.

For example, if the framework gets a request with a bad json body.

```
const app = express():

app.post("/", (req, res) => {
 ...
});

// User error handler
app.use((err, req, res, next) => {
  logger.log(err);
  res.send("Caught error!");
});

functions.http("function, app);
```

```
// Post request with bad JSON
http.post("/", "{"id": "Hello}");
```

The framework responds with the following not very helpful:

```
SyntaxError: Expected double-quoted property name in JSON at position 20 (line 3 column 1)
    at JSON.parse (<anonymous>)
    at parse (functions-framework-nodejs/node_modules/body-parser/lib/types/json.js:92:19)
    at functions-framework-nodejs/node_modules/body-parser/lib/read.js:128:18
    at AsyncResource.runInAsyncScope (node:async_hooks:211:14)
    at invokeCallback (functions-framework-nodejs/node_modules/raw-body/index.js:238:16)
    at done (functions-framework-nodejs/node_modules/raw-body/index.js:227:7)
    at IncomingMessage.onEnd (functions-framework-nodejs/node_modules/raw-body/index.js:287:7)
    at IncomingMessage.emit (node:events:518:28)
    at endReadableNT (node:internal/streams/readable:1698:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
```
    
This change introduces a propagate error to client middleware that when enabled, propagates errors to the user client application where we give power to the user to handle the error, log details, or do whatever they want to do:

```
// Post request with bad JSON
http.post("/", "{"id": "Hello}");
```

The framework responds with a better:

```
"Caught error!"
```