### PR TITLE
fix: add release-assets.githubusercontent.com to allowed domains

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -26,6 +26,7 @@ jobs:
             objects.githubusercontent.com:443
             proxy.golang.org:443
             registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
             storage.googleapis.com:443
             sum.golang.org:443
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -25,6 +25,7 @@ jobs:
             github.com:443
             objects.githubusercontent.com:443
             registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Fix harden list of allowed domains to include release-assets.