### PR TITLE
docs: Fix hanging "For " in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,13 @@ command-line arguments:
 ### Google Cloud Run functions
 
 The [Node.JS runtime on Cloud Run functions](https://cloud.google.com/functions/docs/concepts/nodejs-runtime) utilizes the Node.JS Functions Framework. On Cloud Run functions, the Functions Framework is completely optional: if you don't add it to your `package.json`, it will be
-installed automatically. For
+installed automatically.
 
 After you've written your function, you can simply deploy it from your local
 machine using the `gcloud` command-line tool.
 [Check out the Cloud Functions quickstart](https://cloud.google.com/functions/docs/quickstart).
 
-### Container environments based on KNative
+### Container environments based on Knative
 
 Cloud Run and Cloud Run for Anthos both implement the [Knative Serving API](https://www.knative.dev/docs/). The Functions Framework is designed to be compatible with Knative environments. Just build and deploy your container to a Knative environment.
 


### PR DESCRIPTION
A mysterious hanging "For " was introduced in here: https://github.com/GoogleCloudPlatform/functions-framework-nodejs/commit/b460ab8224e33d34ad753c0480eeb9f10e0dde11#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R160-R162

Also, making the casing of Knative consistent.