### PR TITLE
fix: return 400 for malformed path encoding

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -43,6 +43,18 @@ export function getServer(
 
   // Express middleware
 
+  // Return 400 for URls containing non UTF-8 encoded chars 
+ app.use((req, res, next) => {
+  const pathOnly = req.url.split('?')[0].split('#')[0];
+  try {
+    decodeURIComponent(pathOnly);
+  } catch {
+    res.status(400).send('Bad Request: Invalid URL encoding');
+    return;
+  }
+  next();
+});
+
   // Set request-specific values in the very first middleware.
   app.use('/{*splat}', (req, res, next) => {
     setLatestRes(res);

--- a/test/integration/http.ts
+++ b/test/integration/http.ts
@@ -100,6 +100,14 @@ describe('HTTP Function', () => {
       expectedStatus: 404,
       expectedCallCount: 0,
     },
+    {
+      name: 'GET with non UTF-8 encoded chars',
+      httpVerb: 'GET',
+      path: '/%C3',
+      expectedBody: {},
+      expectedStatus: 400,
+      expectedCallCount: 0,
+    },
   ];
 
   testData.forEach(test => {


### PR DESCRIPTION
## Summary

When the request path contains **invalid percent-encoding** (for example an incomplete sequence like `%C3`), `decodeURIComponent` throws and that error can surface as **500**. This change responds with **400 Bad Request** instead, before the user function runs.

**Context:** [firebase/firebase-functions#1646](https://github.com/firebase/firebase-functions/issues/1646) — malformed paths have been reported as internal errors and noisy logs for HTTP / Cloud Functions workloads built on this framework.

## Changes

- `server.ts` — Early middleware validates the path segment of `req.url` with `decodeURIComponent` in a `try/catch`. On failure, respond with **400** and a short body; do not invoke the user function.
- `test/integration/http.ts` — Integration test `GET with non UTF-8 encoded chars` (path `/%C3`): **400** and handler **not** called (`callCount` unchanged).

## Testing

### Automated

- Case `GET with non UTF-8 encoded chars`: status **400**, empty body (same shape as other non-JSON cases), 
`callCount === 0`.
- `npm test` (after `npm run compile` if needed) passes.

### Manual

1. Build locally
   ```bash
   npm run compile

2. Add small test file to the root e.g.
```javascript
// sample-function.js
const functions = require('./build/src/index.js');

functions.http('hello', (req, res) => {
  res.send('ok');
});
```

3. Start the framework locally, for example:
```bash
functions-framework --target=hello --source=sample-function.js
``` 

4. Request a malformed path and confirm Bad Request (400), **not** 500, for example:
```bash
curl http://127.0.0.1:8080/%C3
```