### PR TITLE
fix: add typesVersions so testing module resolves under classic TypeScript moduleResolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,13 @@
       "default": "./build/src/testing.js"
     }
   },
+  "typesVersions": {
+    "*": {
+      "testing": [
+        "./build/src/testing.d.ts"
+      ]
+    }
+  },
   "dependencies": {
     "@types/express": "^5.0.0",
     "body-parser": "^2.2.2",


### PR DESCRIPTION
## Problem

The `./testing` subpath export is declared in `exports` correctly, but TypeScript's default `moduleResolution: "node"` does not read the `exports` field in `package.json`. This means projects using the default (or older) TypeScript configuration get a type error when importing the testing utilities:

```ts
import { getTestServer } from '@google-cloud/functions-framework/testing';
// Error: Module '@google-cloud/functions-framework/testing' not found
```

Both `getTestServer` and `getFunction` are affected.

## Root Cause

TypeScript only respects `exports` subpath maps when `moduleResolution` is set to `"node16"`, `"nodenext"`, or `"bundler"`. Most projects still use `"node"` (the classic resolver), which only looks at `main` and `types` at the package root.

## Fix

Add a `typesVersions` field, which is the standard way to declare subpath type mappings for all TypeScript versions and moduleResolution modes:

```json
"typesVersions": {
  "*": {
    "testing": ["./build/src/testing.d.ts"]
  }
}
```

This is additive — projects already using `node16`/`bundler` continue using the `exports` map; projects using classic `node` resolution now also work.

## Verification

After this change, the following import works without `moduleResolution: "node16"`:

```ts
import { getTestServer, getFunction } from '@google-cloud/functions-framework/testing';
```

Fixes #594

🤖 Generated with Claude Code