### PR TITLE
fix: add typesVersions so testing module resolves under classic TypeScript moduleResolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,13 @@
       "default": "./build/src/testing.js"
     }
   },
+  "typesVersions": {
+    "*": {
+      "testing": [
+        "./build/src/testing.d.ts"
+      ]
+    }
+  },
   "dependencies": {
     "@types/express": "^5.0.0",
     "body-parser": "^2.2.2",


### PR DESCRIPTION
Recreates #764 to resolve the issue with TypeScript module resolution.

### Original Description
The exports map in package.json correctly declares the ./testing subpath, but TypeScript's moduleResolution: "node" (the default in most projects) does not read the exports field. This caused `getTestServer` and `getFunction` to appear not found when users imported @google-cloud/functions-framework/testing.

Adding typesVersions instructs TypeScript to resolve the testing subpath to ./build/src/testing.d.ts regardless of moduleResolution setting, unblocking users on TypeScript <4.7 or projects that have not yet adopted node16/bundler module resolution.

Fixes #594

Co-authored-by: 64JohnLee <64lamei@gmail.com>
