### PR TITLE
chore(kokoro): correct SCM path prefix for GoB

### DIFF
--- a/.kokoro/build.cfg
+++ b/.kokoro/build.cfg
@@ -2,7 +2,7 @@
 # proto-file: google3/devtools/kokoro/config/proto/build.proto
 # proto-message: BuildConfig
 
-build_file: "serverless/functions-framework-nodejs/.kokoro/build.sh"
+build_file: "git/functions-framework-nodejs/.kokoro/build.sh"
 container_properties {
   docker_image: "us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/node:22.13.1-bookworm"
 }

--- a/.kokoro/release.cfg
+++ b/.kokoro/release.cfg
@@ -2,7 +2,7 @@
 # proto-file: google3/devtools/kokoro/config/proto/build.proto
 # proto-message: BuildConfig
 
-build_file: "serverless/functions-framework-nodejs/.kokoro/release.sh"
+build_file: "git/functions-framework-nodejs/.kokoro/release.sh"
 container_properties {
   docker_image: "us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/ubuntu:22.04"
 }


### PR DESCRIPTION
Bypasses the Kokoro GoB SCM path-prefixing bug by changing 'serverless/' to 'git/' in build.cfg and release.cfg.