### PR TITLE
fix: decode only the viewed bytes of Uint8Array log data

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -163,7 +163,15 @@ function processData(data: Uint8Array | string, encoding?: BufferEncoding) {
   let decodedData;
   try {
     if (data instanceof Uint8Array) {
-      decodedData = Buffer.from(data.buffer).toString();
+      // Decode only the bytes the view actually spans. A Uint8Array (e.g. a
+      // Buffer carved from Node's shared pool) is often a view into a larger
+      // ArrayBuffer, so reading `data.buffer` directly would include unrelated
+      // bytes outside the view's byteOffset/byteLength range.
+      decodedData = Buffer.from(
+        data.buffer,
+        data.byteOffset,
+        data.byteLength,
+      ).toString();
     } else {
       decodedData = Buffer.from(data, encoding).toString();
     }

--- a/test/logger.ts
+++ b/test/logger.ts
@@ -147,6 +147,18 @@ describe('getModifiedData', () => {
     assert.equal(modifiedData, expectedTextOutput);
   });
 
+  it('uint8Array that is a view into a larger (pooled) buffer', () => {
+    // Node.js allocates most Buffers from a shared internal pool, so a Buffer
+    // written to stdout/stderr is frequently a view with a non-zero byteOffset
+    // into a much larger ArrayBuffer. The logger must honor the view's
+    // byteOffset/byteLength rather than decoding the entire backing buffer.
+    const pool = Buffer.alloc(64, 0x2e /* '.' */);
+    const view = pool.subarray(8, 8 + sampleText.length);
+    view.write(sampleText);
+    const modifiedData = getModifiedData(view);
+    assert.equal(modifiedData, expectedTextOutput);
+  });
+
   it('simple text with error', () => {
     const modifiedData = getModifiedData(sampleText, undefined, true);
     const expectedOutput =


### PR DESCRIPTION
## Summary

When execution-id logging is enabled, the framework intercepts `process.stdout`/`process.stderr` writes and re-decodes the data to attach execution context (`src/logger.ts`). The `Uint8Array` branch decoded `data.buffer`:

```js
decodedData = Buffer.from(data.buffer).toString();
```

`data.buffer` is the **entire backing `ArrayBuffer`** and ignores the view's `byteOffset` / `byteLength`. Node.js allocates most `Buffer`s from a shared internal pool, so a `Buffer` written to stdout is frequently a view with a **non-zero `byteOffset`** into a much larger `ArrayBuffer`. As a result, decoding `data.buffer` captures unrelated pool bytes surrounding the real message and produces corrupted log output.

### Reproduction

```js
const pool = Buffer.allocUnsafe(64);
const a = pool.subarray(8, 8 + 11);
a.write('hello world');

Buffer.from(a.buffer).toString();
// => 8192-byte string of pool garbage with "hello world" buried in the middle

Buffer.from(a.buffer, a.byteOffset, a.byteLength).toString();
// => "hello world"
```

In practice this means a user function that does `process.stdout.write(Buffer.from('...'))` (or logs via any library that emits `Buffer`s) gets garbled logs whenever execution-id support is on.

## Fix

Decode only the bytes the view spans:

```js
decodedData = Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString();
```

## Why the existing test didn't catch it

The `uint8array` test uses `new Uint8Array(Buffer.from(sampleText))`, which copies into a fresh, exactly-sized `ArrayBuffer` with `byteOffset === 0` and `byteLength === buffer.byteLength` — the one case where reading `data.buffer` happens to be correct.

## Testing

- Added a regression test that logs through a pooled, non-zero-offset view. It fails before the fix and passes after.
- Full suite green: `107 passing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)