### PR TITLE
chore: add Node.js 24 to github workflows

### DIFF
--- a/.github/workflows/buildpack-integration-test.yml
+++ b/.github/workflows/buildpack-integration-test.yml
@@ -47,3 +47,14 @@ jobs:
       builder-runtime: 'nodejs22'
       builder-runtime-version: '22'
       builder-url: 'us-docker.pkg.dev/serverless-runtimes/google-22-full/builder/nodejs:latest'
+  nodejs24:
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@main
+    with:
+      http-builder-source: 'test/conformance'
+      http-builder-target: 'writeHttpDeclarative'
+      cloudevent-builder-source: 'test/conformance'
+      cloudevent-builder-target: 'writeCloudEventDeclarative'
+      prerun: 'test/conformance/prerun.sh'
+      builder-runtime: 'nodejs24'
+      builder-runtime-version: '24'
+      builder-url: 'us-docker.pkg.dev/serverless-runtimes/google-24-full/builder/nodejs:latest'

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22, 24]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22, 24]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
## Issue

- close https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/706

## Proposed Changes

- Add Node.js 24 to the unit test and conformance test matrices.
- Add a buildpack integration test job for the `nodejs24` runtime. It is provided by the `google-24-full` builder, so it uses a different builder image from the existing jobs.

## References

- https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/680
- https://docs.cloud.google.com/docs/buildpacks/builders