### PR TITLE
chore: add Node.js 26 to github workflows

### DIFF
--- a/.github/workflows/buildpack-integration-test.yml
+++ b/.github/workflows/buildpack-integration-test.yml
@@ -47,3 +47,14 @@ jobs:
       builder-runtime: 'nodejs22'
       builder-runtime-version: '22'
       builder-url: 'us-docker.pkg.dev/serverless-runtimes/google-22-full/builder/nodejs:latest'
+  nodejs24:
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@main
+    with:
+      http-builder-source: 'test/conformance'
+      http-builder-target: 'writeHttpDeclarative'
+      cloudevent-builder-source: 'test/conformance'
+      cloudevent-builder-target: 'writeCloudEventDeclarative'
+      prerun: 'test/conformance/prerun.sh'
+      builder-runtime: 'nodejs24'
+      builder-runtime-version: '24'
+      builder-url: 'us-docker.pkg.dev/serverless-runtimes/google-24-full/builder/nodejs:latest'

--- a/.github/workflows/buildpack-integration-test.yml
+++ b/.github/workflows/buildpack-integration-test.yml
@@ -58,3 +58,14 @@ jobs:
       builder-runtime: 'nodejs24'
       builder-runtime-version: '24'
       builder-url: 'us-docker.pkg.dev/serverless-runtimes/google-24-full/builder/nodejs:latest'
+  nodejs26:
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@main
+    with:
+      http-builder-source: 'test/conformance'
+      http-builder-target: 'writeHttpDeclarative'
+      cloudevent-builder-source: 'test/conformance'
+      cloudevent-builder-target: 'writeCloudEventDeclarative'
+      prerun: 'test/conformance/prerun.sh'
+      builder-runtime: 'nodejs26'
+      builder-runtime-version: '26'
+      builder-url: 'us-docker.pkg.dev/serverless-runtimes/google-24-full/builder/nodejs:latest'

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22, 24]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22, 24]
+        node-version: [18, 20, 22, 24, 26]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: [18, 20, 22, 24]
+        node-version: [18, 20, 22, 24, 26]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22, 24]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
## Proposed Changes

- Add Node.js 26 to the unit test and conformance test matrices.
- Add a buildpack integration test job for the `nodejs26` runtime. It is provided by the same `google-24-full` builder as `nodejs24`.

## Notes

**This PR is stacked on #801**, which adds Node.js 24. Until #801 is merged this PR shows both commits; I will rebase it afterwards. Feel free to merge #801 first and ignore this one until Node.js 26 goes GA as a runtime.

## References

- https://github.com/cloudevents/sdk-javascript/pull/655
- https://docs.cloud.google.com/docs/buildpacks/builders